### PR TITLE
UI for challenges

### DIFF
--- a/app/src/main/java/com/example/brainracer/ui/components/ChallengeFriendQuizSheetContent.kt
+++ b/app/src/main/java/com/example/brainracer/ui/components/ChallengeFriendQuizSheetContent.kt
@@ -1,0 +1,180 @@
+package com.example.brainracer.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Quiz
+import androidx.compose.material.icons.filled.Sports
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.brainracer.domain.entities.User
+import com.example.brainracer.ui.utils.QuizItem
+
+/**
+ * Контент bottom sheet: выбор друга (если не зафиксирован) и викторины для вызова.
+ */
+@Composable
+fun ChallengeFriendQuizSheetContent(
+    fixedFriend: User?,
+    friends: List<User>,
+    quizzes: List<QuizItem>,
+    isLoading: Boolean,
+    onDismiss: () -> Unit,
+    onSendChallenge: (friendId: String, quizId: String, quizTitle: String) -> Unit
+) {
+    var selectedFriend by remember(fixedFriend?.id) { mutableStateOf(fixedFriend) }
+
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 24.dp)
+            .navigationBarsPadding()
+    ) {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Бросить вызов",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp
+            )
+            TextButton(onClick = onDismiss) { Text("Закрыть") }
+        }
+
+        if (fixedFriend == null && selectedFriend == null) {
+            Text(
+                "Выберите друга",
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            when {
+                isLoading -> Box(Modifier.fillMaxWidth().height(120.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                friends.isEmpty() -> Text(
+                    "Сначала добавьте друзей на вкладке «My friends».",
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                else -> LazyColumn(
+                    modifier = Modifier.heightIn(max = 280.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(friends, key = { it.id }) { u ->
+                        FriendPickRow(u) { selectedFriend = u }
+                    }
+                }
+            }
+            return
+        }
+
+        val friend = selectedFriend ?: fixedFriend!!
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(bottom = 10.dp)) {
+            if (fixedFriend == null) {
+                IconButton(onClick = { selectedFriend = null }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
+                }
+            }
+            Column(Modifier.weight(1f)) {
+                Text(
+                    friend.nickname,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 16.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    "Выберите викторину",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        when {
+            isLoading -> Box(Modifier.fillMaxWidth().height(160.dp), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            quizzes.isEmpty() -> Text(
+                "Нет доступных викторин.",
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            else -> LazyColumn(
+                modifier = Modifier.heightIn(max = 360.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(quizzes, key = { it.id }) { q ->
+                    QuizPickRow(q) {
+                        onSendChallenge(friend.id, q.id, q.title)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FriendPickRow(user: User, onClick: () -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(Icons.Default.Sports, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            Column(Modifier.weight(1f)) {
+                Text(user.nickname, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(user.rank.displayName, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuizPickRow(quiz: QuizItem, onClick: () -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(Icons.Default.Quiz, contentDescription = null, tint = MaterialTheme.colorScheme.secondary)
+            Column(Modifier.weight(1f)) {
+                Text(quiz.title, fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Text(
+                    "${quiz.questionCount} вопр. · ${quiz.category}",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/brainracer/ui/screens/ChallendgeRoundReviewScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ChallendgeRoundReviewScreen.kt
@@ -1,0 +1,393 @@
+package com.example.brainracer.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.brainracer.data.repositories.ChallengeRepositoryImpl
+import com.example.brainracer.data.repositories.QuizRepositoryImpl
+import com.example.brainracer.data.utils.Result
+import com.example.brainracer.domain.entities.Challenge
+import com.example.brainracer.domain.entities.ChallengeStatus
+import com.example.brainracer.domain.entities.Question
+import com.example.brainracer.domain.entities.UserAnswer
+import com.google.firebase.auth.FirebaseAuth
+
+// ─── Палитра (та же что в ChallengesScreen) ──────────────────────────────────
+private val RBg      = Color(0xFF0F0F1A)
+private val RCard    = Color(0xFF1A1A2E)
+private val RBorder  = Color(0xFF2A2A3E)
+private val RPurple  = Color(0xFF667EEA)
+private val RGreen   = Color(0xFF3ECFA3)
+private val RRed     = Color(0xFFEA5C7E)
+private val ROrange  = Color(0xFFFFA726)
+private val RGold    = Color(0xFFFFD700)
+private val RTextPri = Color(0xFFFFFFFF)
+private val RTextSec = Color(0xFF8B8AAE)
+
+// ══════════════════════════════════════════════════════════════════════════════
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChallengeRoundReviewScreen(
+    challengeId: String,
+    navController: NavController
+) {
+    val challengeRepo = remember { ChallengeRepositoryImpl() }
+    val quizRepo      = remember { QuizRepositoryImpl() }
+    val currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    var challenge  by remember { mutableStateOf<Challenge?>(null) }
+    var questions  by remember { mutableStateOf<List<Question>>(emptyList()) }
+    var isLoading  by remember { mutableStateOf(true) }
+    var error      by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(challengeId) {
+        when (val r = challengeRepo.getChallenge(challengeId)) {
+            is Result.Success -> {
+                val ch = r.data
+                challenge = ch
+                when (val qr = quizRepo.getQuiz(ch.quizId)) {
+                    is Result.Success -> questions = qr.data.questions
+                    is Result.Error   -> error = "Не удалось загрузить вопросы"
+                }
+            }
+            is Result.Error -> error = "Вызов не найден"
+        }
+        isLoading = false
+    }
+
+    Scaffold(
+        containerColor      = RBg,
+        contentWindowInsets = WindowInsets.systemBars,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Разбор раунда", color = RTextPri,
+                        fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Box(Modifier.size(36.dp).clip(CircleShape).background(RCard),
+                            contentAlignment = Alignment.Center) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, null,
+                                tint = RTextPri, modifier = Modifier.size(18.dp))
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = RBg)
+            )
+        }
+    ) { padding ->
+        when {
+            isLoading -> Box(Modifier.fillMaxSize(), Alignment.Center) {
+                CircularProgressIndicator(color = RPurple)
+            }
+            error != null -> Box(Modifier.fillMaxSize(), Alignment.Center) {
+                Text(error!!, color = RRed, textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(24.dp))
+            }
+            challenge != null -> {
+                val ch = challenge!!
+                val isChallenger    = ch.challengerUserId == currentUserId
+                val myResult        = if (isChallenger) ch.challengerResult else ch.challengedResult
+                val opponentResult  = if (isChallenger) ch.challengedResult else ch.challengerResult
+                val opponentName    = if (isChallenger) ch.challengedNickname else ch.challengerNickname
+
+                LazyColumn(
+                    modifier            = Modifier.fillMaxSize().padding(padding),
+                    contentPadding      = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    // Итоговый счёт
+                    item {
+                        ScoreHeader(
+                            challenge     = ch,
+                            opponentName  = opponentName,
+                            currentUserId = currentUserId
+                        )
+                    }
+
+                    // Вопросы
+                    itemsIndexed(questions) { i, question ->
+                        val myAnswer = myResult?.answers?.find { it.questionId == question.id }
+                            ?: myResult?.answers?.getOrNull(i)
+                        val opponentAnswer = opponentResult?.answers?.find { it.questionId == question.id }
+                            ?: opponentResult?.answers?.getOrNull(i)
+                        QuestionComparisonCard(
+                            index          = i,
+                            question       = question,
+                            myAnswer       = myAnswer,
+                            opponentAnswer = opponentAnswer,
+                            myLabel        = "Вы",
+                            opponentLabel  = opponentName.split(" ").first()
+                        )
+                    }
+
+                    item { Spacer(Modifier.height(16.dp)) }
+                }
+            }
+        }
+    }
+}
+
+// ── Итоговый счёт ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ScoreHeader(
+    challenge: Challenge,
+    opponentName: String,
+    currentUserId: String
+) {
+    val myResult = if (challenge.challengerUserId == currentUserId) {
+        challenge.challengerResult
+    } else {
+        challenge.challengedResult
+    }
+    val opponentResult = if (challenge.challengerUserId == currentUserId) {
+        challenge.challengedResult
+    } else {
+        challenge.challengerResult
+    }
+
+    val finished = challenge.status == ChallengeStatus.COMPLETED
+    val isDraw   = challenge.isDraw || challenge.winnerId == "draw"
+    val isWin    = finished && !isDraw && challenge.winnerId == currentUserId
+
+    val (resultLabel, resultColor) = when {
+        !finished -> when {
+            myResult == null && opponentResult == null ->
+                "Вызов принят" to RTextSec
+            myResult != null && opponentResult == null ->
+                "Ожидаем соперника" to ROrange
+            myResult == null && opponentResult != null ->
+                "Ваш ход" to RPurple
+            else -> "В процессе" to RTextSec
+        }
+        isDraw -> "Ничья" to ROrange
+        isWin  -> "Победа" to RGreen
+        else   -> "Поражение" to RRed
+    }
+
+    val myScoreDisplay     = myResult?.score
+    val oppScoreDisplay    = opponentResult?.score
+    val hideMyScore        = !finished && myResult == null
+    val hideOpponentScore  = !finished && opponentResult == null
+
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(20.dp),
+        colors    = CardDefaults.cardColors(containerColor = RCard),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Результат
+            Surface(shape = RoundedCornerShape(10.dp), color = resultColor.copy(.15f)) {
+                Text(resultLabel,
+                    modifier   = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                    fontWeight = FontWeight.Bold, fontSize = 14.sp, color = resultColor)
+            }
+
+            // Счёт
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                PlayerScoreColumn(
+                    name      = "Вы",
+                    score     = myScoreDisplay,
+                    isWinner  = isWin,
+                    hideScore = hideMyScore
+                )
+                Text(":", fontSize = 28.sp, fontWeight = FontWeight.Bold, color = RTextSec)
+                val oppWins = finished && !isDraw && !isWin
+                PlayerScoreColumn(
+                    name      = opponentName.split(" ").first(),
+                    score     = oppScoreDisplay,
+                    isWinner  = oppWins,
+                    hideScore = hideOpponentScore
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerScoreColumn(
+    name: String,
+    score: Int?,
+    isWinner: Boolean,
+    hideScore: Boolean
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(name, fontSize = 13.sp, color = RTextSec)
+        Text(
+            if (hideScore) "—" else "${score ?: 0}",
+            fontWeight = FontWeight.Bold,
+            fontSize   = 32.sp,
+            color      = when {
+                hideScore -> RTextSec
+                isWinner  -> RGreen
+                else      -> RTextPri
+            }
+        )
+        if (isWinner) {
+            Icon(Icons.Default.EmojiEvents, null, tint = RGold, modifier = Modifier.size(18.dp))
+        }
+    }
+}
+
+// ── Карточка сравнения вопроса ────────────────────────────────────────────────
+
+@Composable
+private fun QuestionComparisonCard(
+    index: Int,
+    question: Question,
+    myAnswer: UserAnswer?,
+    opponentAnswer: UserAnswer?,
+    myLabel: String,
+    opponentLabel: String
+) {
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(18.dp),
+        colors    = CardDefaults.cardColors(containerColor = RCard),
+        elevation = CardDefaults.cardElevation(0.dp),
+        border    = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+
+            // Номер + текст вопроса
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.Top) {
+                Surface(shape = RoundedCornerShape(6.dp), color = RPurple.copy(.15f)) {
+                    Text("${index + 1}", modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                        fontSize = 11.sp, fontWeight = FontWeight.Bold, color = RPurple)
+                }
+                Text(question.questionText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold,
+                    color = RTextPri, lineHeight = 20.sp, modifier = Modifier.weight(1f))
+            }
+
+            // Варианты ответов
+            val letters = listOf("A", "B", "C", "D", "E")
+            question.options.forEachIndexed { optIdx, optText ->
+                val isCorrect      = question.correctAnswerIndex == optIdx
+                val iMyChoice      = myAnswer?.selectedAnswerIndex == optIdx
+                val isOpponentChoice = opponentAnswer?.selectedAnswerIndex == optIdx
+
+                // Определяем цвет строки
+                val rowColor = when {
+                    isCorrect -> RGreen
+                    iMyChoice || isOpponentChoice -> RRed
+                    else -> RBorder
+                }
+                val rowBg = when {
+                    isCorrect -> RGreen.copy(.08f)
+                    iMyChoice || isOpponentChoice -> RRed.copy(.08f)
+                    else -> Color.Transparent
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(rowBg)
+                        .border(1.dp, rowColor.copy(.3f), RoundedCornerShape(8.dp))
+                        .padding(horizontal = 10.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // Буква
+                    Text(letters.getOrElse(optIdx) { "$optIdx" },
+                        fontSize = 11.sp, fontWeight = FontWeight.Bold, color = rowColor,
+                        modifier = Modifier.width(16.dp), textAlign = TextAlign.Center)
+
+                    // Текст варианта
+                    Text(optText, fontSize = 13.sp, color = RTextPri,
+                        modifier = Modifier.weight(1f))
+
+                    // Иконки: кто выбрал этот вариант
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        if (iMyChoice) {
+                            AnswerTag(myLabel, if (myAnswer?.isCorrect == true) RGreen else RRed)
+                        }
+                        if (isOpponentChoice) {
+                            AnswerTag(opponentLabel, if (opponentAnswer?.isCorrect == true) RGreen else RRed)
+                        }
+                        if (isCorrect) {
+                            Icon(Icons.Default.CheckCircle, null,
+                                tint = RGreen, modifier = Modifier.size(15.dp))
+                        }
+                    }
+                }
+            }
+
+            // Время ответа обоих игроков
+            HorizontalDivider(color = RBorder.copy(.5f))
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                TimeChip(myLabel, myAnswer?.timeSpent, myAnswer?.isCorrect)
+                TimeChip(opponentLabel, opponentAnswer?.timeSpent, opponentAnswer?.isCorrect)
+            }
+
+            // Объяснение
+            if (!question.explanation.isNullOrBlank()) {
+                Row(verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Icon(Icons.Default.Lightbulb, null,
+                        tint = RGold, modifier = Modifier.size(14.dp).padding(top = 1.dp))
+                    Text(question.explanation!!, fontSize = 12.sp, color = RTextSec, lineHeight = 17.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnswerTag(label: String, color: Color) {
+    Surface(shape = RoundedCornerShape(4.dp), color = color.copy(.15f)) {
+        Text(label, modifier = Modifier.padding(horizontal = 5.dp, vertical = 2.dp),
+            fontSize = 10.sp, fontWeight = FontWeight.SemiBold, color = color)
+    }
+}
+
+@Composable
+private fun TimeChip(label: String, timeSpent: Int?, isCorrect: Boolean?) {
+    val color = when (isCorrect) {
+        true  -> RGreen
+        false -> RRed
+        null  -> RTextSec
+    }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(label, fontSize = 11.sp, color = RTextSec)
+        Text(
+            if (timeSpent != null && timeSpent >= 0) "${timeSpent}с" else "—",
+            fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = color
+        )
+    }
+}
+
+

--- a/app/src/main/java/com/example/brainracer/ui/screens/ChallengeScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ChallengeScreen.kt
@@ -1,0 +1,702 @@
+package com.example.brainracer.ui.screens
+
+import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.brainracer.domain.entities.Challenge
+import com.example.brainracer.domain.entities.ChallengeStatus
+import com.example.brainracer.ui.components.BottomBar
+import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
+import com.example.brainracer.ui.viewmodels.ChallengeViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
+
+// ─── Палитра ────────────────────────────────────────────────────────────────
+private val CBg      = Color(0xFF0F0F1A)
+private val CCard    = Color(0xFF1A1A2E)
+private val CBorder  = Color(0xFF2A2A3E)
+private val CPurple  = Color(0xFF667EEA)
+private val CGreen   = Color(0xFF3ECFA3)
+private val CRed     = Color(0xFFEA5C7E)
+private val COrange  = Color(0xFFFFA726)
+private val CTextPri = Color(0xFFFFFFFF)
+private val CTextSec = Color(0xFF8B8AAE)
+
+// ══════════════════════════════════════════════════════════════════════════════
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun ChallengesScreen(
+    navController: NavController,
+    currentUserId: String,
+    vm: ChallengeViewModel = viewModel(),
+    onHomeClick: () -> Unit = {},
+    onFriendsClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
+    currentRoute: String = "challenges"
+) {
+    val uiState     by vm.uiState.collectAsState()
+    val context     = LocalContext.current
+    val pagerState  = rememberPagerState { 3 }
+    val scope       = rememberCoroutineScope()
+    val tabTitles   = listOf("Входящие", "Активные", "Завершённые")
+
+    var showChallengeSheet by remember { mutableStateOf(false) }
+    val challengeSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(uiState.challengeSentMessage) {
+        uiState.challengeSentMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            vm.consumeChallengeSentMessage()
+            showChallengeSheet = false
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_LONG).show()
+            vm.clearError()
+        }
+    }
+
+    LaunchedEffect(showChallengeSheet) {
+        if (showChallengeSheet) vm.loadChallengePickerData()
+    }
+
+    // Badge counts
+    val incomingCount = uiState.incomingChallenges.size
+    val activeCount   = uiState.activeChallenges.size +
+            uiState.outgoingChallenges.count { it.status == ChallengeStatus.PENDING }
+
+    if (showChallengeSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showChallengeSheet = false },
+            sheetState       = challengeSheetState,
+            containerColor   = CCard,
+            contentColor     = CTextPri
+        ) {
+            ChallengeFriendQuizSheetContent(
+                fixedFriend   = null,
+                friends       = uiState.friendsForChallenge,
+                quizzes       = uiState.challengePickerQuizzes,
+                isLoading     = uiState.challengePickerLoading,
+                onDismiss     = { showChallengeSheet = false },
+                onSendChallenge = { fid, qid, title ->
+                    vm.sendChallengeFromPicker(fid, qid, title)
+                }
+            )
+        }
+    }
+
+    Scaffold(
+        containerColor = CBg,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Вызовы", fontWeight = FontWeight.Bold,
+                        fontSize = 20.sp, color = CTextPri)
+                },
+                actions = {
+                    TextButton(onClick = { showChallengeSheet = true }) {
+                        Icon(
+                            Icons.Default.Sports,
+                            contentDescription = null,
+                            tint     = CPurple,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text("Вызов", color = CPurple, fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = CBg),
+                modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
+            )
+        },
+        bottomBar = {
+            BottomBar(
+                showBar        = true,
+                currentRoute   = currentRoute,
+                onHomeClick    = onHomeClick,
+                onFriendsClick = onFriendsClick,
+                onProfileClick = onProfileClick
+            )
+        }
+    ) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding)) {
+
+            // ── Вкладки ───────────────────────────────────────────────────
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                containerColor   = CBg,
+                contentColor     = CPurple,
+                indicator = { positions ->
+                    if (pagerState.currentPage < positions.size) {
+                        TabRowDefaults.Indicator(
+                            modifier = Modifier.tabIndicatorOffset(positions[pagerState.currentPage])
+                                .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp)),
+                            color    = CPurple, height = 3.dp
+                        )
+                    }
+                },
+                divider = { HorizontalDivider(color = CBorder) }
+            ) {
+                tabTitles.forEachIndexed { i, title ->
+                    val badge = when (i) {
+                        0 -> incomingCount
+                        1 -> activeCount
+                        else -> 0
+                    }
+                    Tab(
+                        selected               = pagerState.currentPage == i,
+                        onClick                = { scope.launch { pagerState.animateScrollToPage(i) } },
+                        selectedContentColor   = CPurple,
+                        unselectedContentColor = CTextSec
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 13.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(title, fontSize = 13.sp,
+                                fontWeight = if (pagerState.currentPage == i) FontWeight.SemiBold
+                                else FontWeight.Normal)
+                            if (badge > 0) {
+                                Badge { Text("$badge") }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Контент страниц ───────────────────────────────────────────
+            HorizontalPager(
+                state    = pagerState,
+                modifier = Modifier.weight(1f)
+            ) { page ->
+                when {
+                    uiState.isLoading -> CenteredLoader()
+                    page == 0 -> IncomingTab(
+                        challenges    = uiState.incomingChallenges,
+                        currentUserId = currentUserId,
+                        onAccept      = { vm.acceptChallenge(it.id) },
+                        onDecline     = { vm.declineChallenge(it.id) }
+                    )
+                    page == 1 -> {
+                        val outgoingPending = uiState.outgoingChallenges
+                            .filter { it.status == ChallengeStatus.PENDING }
+                        val mergedActive = (uiState.activeChallenges + outgoingPending)
+                            .distinctBy { it.id }
+                            .sortedWith(
+                                compareByDescending<Challenge> { it.createdAt.seconds }
+                                    .thenByDescending { it.createdAt.nanoseconds }
+                            )
+                        ActiveTab(
+                            challenges    = mergedActive,
+                            currentUserId = currentUserId,
+                            onCancelPending = { vm.cancelChallenge(it.id) },
+                            onPlay          = { challenge ->
+                                navController.navigate(
+                                    "quiz_play/${challenge.quizId}?challengeId=${challenge.id}"
+                                )
+                            },
+                            onViewRound     = { challenge ->
+                                navController.navigate("challenge_review/${challenge.id}")
+                            }
+                        )
+                    }
+                    else -> HistoryTab(
+                        completed     = uiState.completedChallenges,
+                        currentUserId = currentUserId,
+                        onViewRound   = { challenge ->
+                            navController.navigate("challenge_review/${challenge.id}")
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+//  ВКЛАДКА: ВХОДЯЩИЕ
+// ══════════════════════════════════════════════════════════════════════════════
+
+@Composable
+private fun IncomingTab(
+    challenges: List<Challenge>,
+    currentUserId: String,
+    onAccept: (Challenge) -> Unit,
+    onDecline: (Challenge) -> Unit
+) {
+    if (challenges.isEmpty()) {
+        EmptyState("Нет входящих вызовов", "Когда друг бросит вызов — он появится здесь")
+        return
+    }
+    LazyColumn(
+        contentPadding      = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(challenges, key = { it.id }) { ch ->
+            IncomingChallengeCard(
+                challenge = ch,
+                onAccept  = { onAccept(ch) },
+                onDecline = { onDecline(ch) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun IncomingChallengeCard(
+    challenge: Challenge,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit
+) {
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(18.dp),
+        colors    = CardDefaults.cardColors(containerColor = CCard),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            // Заголовок
+            Row(verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                AvatarCircle(challenge.challengerNickname.take(2).uppercase(), CPurple, 44)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(challenge.challengerNickname, fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp, color = CTextPri)
+                    Text("бросает вам вызов", fontSize = 12.sp, color = CTextSec)
+                }
+                Surface(shape = RoundedCornerShape(8.dp), color = COrange.copy(.15f)) {
+                    Text("Новый", modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                        fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = COrange)
+                }
+            }
+
+            // Викторина
+            Row(verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(Icons.Default.Quiz, null, tint = CPurple, modifier = Modifier.size(16.dp))
+                Text(challenge.quizTitle, fontSize = 13.sp, color = CTextSec,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+            }
+
+            // Срок истечения
+            Text(
+                "Истекает: ${formatTimestamp(challenge.expiresAt.seconds * 1000)}",
+                fontSize = 11.sp, color = CTextSec
+            )
+
+            // Кнопки
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = onAccept,
+                    modifier = Modifier.weight(1f),
+                    shape  = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = CGreen)
+                ) {
+                    Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Принять", fontSize = 13.sp, color = Color.White)
+                }
+                OutlinedButton(
+                    onClick = onDecline,
+                    modifier = Modifier.weight(1f),
+                    shape  = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = CRed),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, CRed)
+                ) {
+                    Icon(Icons.Default.Close, null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Отклонить", fontSize = 13.sp)
+                }
+            }
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+//  ВКЛАДКА: АКТИВНЫЕ
+// ══════════════════════════════════════════════════════════════════════════════
+
+@Composable
+private fun ActiveTab(
+    challenges: List<Challenge>,
+    currentUserId: String,
+    onCancelPending: (Challenge) -> Unit,
+    onPlay: (Challenge) -> Unit,
+    onViewRound: (Challenge) -> Unit
+) {
+    if (challenges.isEmpty()) {
+        EmptyState("Нет активных вызовов", "Примите входящий вызов или бросьте вызов другу")
+        return
+    }
+    val pendingOutgoing = challenges.filter {
+        it.status == ChallengeStatus.PENDING && it.challengerUserId == currentUserId
+    }.sortedWith(
+        compareByDescending<Challenge> { it.createdAt.seconds }
+            .thenByDescending { it.createdAt.nanoseconds }
+    )
+    val acceptedInPlay = challenges.filter { it.status == ChallengeStatus.ACCEPTED }
+        .sortedWith(
+            compareByDescending<Challenge> { it.createdAt.seconds }
+                .thenByDescending { it.createdAt.nanoseconds }
+        )
+
+    LazyColumn(
+        contentPadding      = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (pendingOutgoing.isNotEmpty()) {
+            item {
+                ActiveSectionHeader(
+                    title    = "В обработке",
+                    subtitle = "Ожидание принятия или отклонения вызова соперником"
+                )
+            }
+            items(pendingOutgoing, key = { it.id }) { ch ->
+                OutgoingPendingCard(challenge = ch, onCancel = { onCancelPending(ch) })
+            }
+        }
+        if (acceptedInPlay.isNotEmpty()) {
+            item {
+                ActiveSectionHeader(
+                    title    = "Принятые дуэли",
+                    subtitle = "Можно проходить викторину, пока не истёк срок"
+                )
+            }
+            items(acceptedInPlay, key = { it.id }) { ch ->
+                ActiveChallengeCard(
+                    challenge     = ch,
+                    currentUserId = currentUserId,
+                    onPlay        = { onPlay(ch) },
+                    onViewRound   = { onViewRound(ch) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActiveSectionHeader(title: String, subtitle: String) {
+    Column(Modifier.fillMaxWidth().padding(bottom = 4.dp)) {
+        Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold, color = CTextPri)
+        Text(subtitle, fontSize = 11.sp, color = CTextSec, lineHeight = 14.sp)
+    }
+}
+
+@Composable
+private fun ActiveChallengeCard(
+    challenge: Challenge,
+    currentUserId: String,
+    onPlay: () -> Unit,
+    onViewRound: () -> Unit
+) {
+    val isChallenger   = challenge.challengerUserId == currentUserId
+    val opponentName   = if (isChallenger) challenge.challengedNickname else challenge.challengerNickname
+    val myResult       = if (isChallenger) challenge.challengerResult else challenge.challengedResult
+    val opponentResult = if (isChallenger) challenge.challengedResult else challenge.challengerResult
+    val iAlreadyPlayed = myResult != null
+    val bothPlayed     = myResult != null && opponentResult != null
+
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(18.dp),
+        colors    = CardDefaults.cardColors(containerColor = CCard),
+        elevation = CardDefaults.cardElevation(0.dp),
+        border    = CardDefaults.outlinedCardBorder()
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            // Соперник
+            Row(verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                AvatarCircle(opponentName.take(2).uppercase(), CGreen, 44)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("vs $opponentName", fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp, color = CTextPri)
+                    Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            }
+
+            // Статусы игроков (счёт скрыт до завершения обоих)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                PlayerStatusChip(
+                    label  = "Вы",
+                    played = iAlreadyPlayed,
+                    score  = if (bothPlayed) myResult?.score else null
+                )
+                PlayerStatusChip(
+                    label  = opponentName.split(" ").first(),
+                    played = opponentResult != null,
+                    score  = if (bothPlayed) opponentResult?.score else null
+                )
+            }
+
+            // Кнопки
+            if (!iAlreadyPlayed) {
+                Button(
+                    onClick  = onPlay,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape    = RoundedCornerShape(10.dp),
+                    colors   = ButtonDefaults.buttonColors(containerColor = CPurple)
+                ) {
+                    Icon(Icons.Default.PlayArrow, null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Пройти викторину", fontWeight = FontWeight.SemiBold)
+                }
+            } else if (bothPlayed) {
+                OutlinedButton(
+                    onClick  = onViewRound,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape    = RoundedCornerShape(10.dp),
+                    colors   = ButtonDefaults.outlinedButtonColors(contentColor = CPurple),
+                    border   = androidx.compose.foundation.BorderStroke(1.dp, CPurple)
+                ) {
+                    Icon(Icons.Default.Analytics, null, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Просмотр раунда")
+                }
+            } else {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape    = RoundedCornerShape(10.dp),
+                    color    = CBorder
+                ) {
+                    Row(
+                        modifier              = Modifier.padding(12.dp),
+                        verticalAlignment     = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier  = Modifier.size(14.dp),
+                            color     = CTextSec,
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text("Ждём хода соперника…", fontSize = 13.sp, color = CTextSec)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerStatusChip(label: String, played: Boolean, score: Int?) {
+    Surface(
+        shape  = RoundedCornerShape(8.dp),
+        color  = if (played) CGreen.copy(.12f) else CBorder
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
+            Icon(
+                imageVector = if (played) Icons.Default.CheckCircle else Icons.Default.HourglassEmpty,
+                contentDescription = null,
+                tint = if (played) CGreen else CTextSec,
+                modifier = Modifier.size(13.dp)
+            )
+            Text(
+                text = if (score != null) "$label: $score" else label,
+                fontSize = 12.sp,
+                color    = if (played) CGreen else CTextSec,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+//  ВКЛАДКА: ИСТОРИЯ
+// ══════════════════════════════════════════════════════════════════════════════
+
+@Composable
+private fun HistoryTab(
+    completed: List<Challenge>,
+    currentUserId: String,
+    onViewRound: (Challenge) -> Unit
+) {
+    if (completed.isEmpty()) {
+        EmptyState("Нет завершённых вызовов", "Завершённые дуэли появятся здесь")
+        return
+    }
+
+    LazyColumn(
+        contentPadding      = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(completed, key = { it.id }) { ch ->
+            CompletedChallengeCard(
+                challenge     = ch,
+                currentUserId = currentUserId,
+                onViewRound   = { onViewRound(ch) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun OutgoingPendingCard(challenge: Challenge, onCancel: () -> Unit) {
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(16.dp),
+        colors    = CardDefaults.cardColors(containerColor = CCard),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            AvatarCircle(challenge.challengedNickname.take(2).uppercase(), COrange, 42)
+            Column(modifier = Modifier.weight(1f)) {
+                Text("→ ${challenge.challengedNickname}", fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp, color = CTextPri)
+                Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("В обработке · ждём соперника", fontSize = 11.sp, color = COrange)
+            }
+            IconButton(onClick = onCancel) {
+                Icon(Icons.Default.Cancel, null, tint = CTextSec, modifier = Modifier.size(20.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompletedChallengeCard(
+    challenge: Challenge,
+    currentUserId: String,
+    onViewRound: () -> Unit
+) {
+    val isChallenger   = challenge.challengerUserId == currentUserId
+    val opponentName   = if (isChallenger) challenge.challengedNickname else challenge.challengerNickname
+    val myScore        = if (isChallenger) challenge.challengerResult?.score ?: 0
+    else challenge.challengedResult?.score ?: 0
+    val opponentScore  = if (isChallenger) challenge.challengedResult?.score ?: 0
+    else challenge.challengerResult?.score ?: 0
+
+    val isDraw = challenge.isDraw || challenge.winnerId == "draw"
+    val isWin  = !isDraw && challenge.winnerId == currentUserId
+    val (resultLabel, resultColor) = when {
+        isDraw -> "Ничья" to COrange
+        isWin  -> "Победа" to CGreen
+        else   -> "Поражение" to CRed
+    }
+
+    Card(
+        modifier  = Modifier.fillMaxWidth().clickable { onViewRound() },
+        shape     = RoundedCornerShape(16.dp),
+        colors    = CardDefaults.cardColors(containerColor = CCard),
+        elevation = CardDefaults.cardElevation(0.dp),
+        border    = CardDefaults.outlinedCardBorder()
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            AvatarCircle(opponentName.take(2).uppercase(), CPurple, 42)
+            Column(modifier = Modifier.weight(1f)) {
+                Text("vs $opponentName", fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp, color = CTextPri)
+                Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    formatTimestamp(challenge.completedAt?.seconds?.times(1000) ?: 0L),
+                    fontSize = 11.sp, color = CTextSec
+                )
+            }
+            Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text("$myScore : $opponentScore", fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp, color = CTextPri)
+                Surface(shape = RoundedCornerShape(6.dp), color = resultColor.copy(.15f)) {
+                    Text(resultLabel,
+                        modifier   = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                        fontSize   = 11.sp, fontWeight = FontWeight.SemiBold, color = resultColor)
+                }
+            }
+            Icon(Icons.AutoMirrored.Filled.ArrowForward, null,
+                tint = CTextSec, modifier = Modifier.size(16.dp))
+        }
+    }
+}
+
+// ── Общие компоненты ──────────────────────────────────────────────────────────
+
+@Composable
+private fun CenteredLoader() {
+    Box(Modifier.fillMaxSize(), Alignment.Center) {
+        CircularProgressIndicator(color = CPurple)
+    }
+}
+
+@Composable
+private fun EmptyState(title: String, subtitle: String) {
+    Box(Modifier.fillMaxSize().padding(32.dp), Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(Modifier.size(72.dp).clip(CircleShape).background(CCard), Alignment.Center) {
+                Icon(Icons.Default.Sports, null, tint = CTextSec, modifier = Modifier.size(32.dp))
+            }
+            Text(title, fontSize = 17.sp, fontWeight = FontWeight.SemiBold,
+                color = CTextPri, textAlign = TextAlign.Center)
+            Text(subtitle, fontSize = 14.sp, color = CTextSec, textAlign = TextAlign.Center)
+        }
+    }
+}
+
+@Composable
+private fun AvatarCircle(initials: String, color: Color, size: Int) {
+    Box(
+        modifier = Modifier.size(size.dp).clip(CircleShape).background(color.copy(.2f))
+            .border(1.dp, color.copy(.4f), CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(initials, color = color, fontWeight = FontWeight.Bold, fontSize = (size / 3).sp)
+    }
+}
+
+private fun formatTimestamp(millis: Long): String {
+    if (millis == 0L) return ""
+    return SimpleDateFormat("d MMM, HH:mm", Locale("ru")).format(Date(millis))
+}
+

--- a/app/src/main/java/com/example/brainracer/ui/screens/FriendListScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/FriendListScreen.kt
@@ -1,5 +1,6 @@
 package com.example.brainracer.ui.screens
 
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,6 +18,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -27,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.brainracer.domain.entities.User
 import com.example.brainracer.ui.components.BottomBar
+import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
 import com.example.brainracer.ui.utils.FriendRequestUi
 import com.example.brainracer.ui.utils.OutgoingRequestUi
 import com.example.brainracer.ui.viewmodels.FriendsViewModel
@@ -48,6 +51,18 @@ fun FriendsScreen(
     // Каждый раз, когда ViewModel обновляет _uiState, Compose автоматически
     // перерисует только те части дерева, которые читают изменившиеся поля.
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    var challengeTargetFriend by remember { mutableStateOf<User?>(null) }
+    val challengeSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(uiState.challengeSentMessage) {
+        uiState.challengeSentMessage?.let { msg ->
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            viewModel.consumeChallengeSentMessage()
+            challengeTargetFriend = null
+        }
+    }
 
     // Локальное состояние только для текста поля поиска —
     // так мы избегаем лишних emit-ов в ViewModel при каждом нажатии клавиши.
@@ -64,6 +79,26 @@ fun FriendsScreen(
     }
     val filteredOutgoing = uiState.outgoingRequests.filter {
         it.receiverName.contains(searchQuery, ignoreCase = true)
+    }
+
+    if (challengeTargetFriend != null) {
+        ModalBottomSheet(
+            onDismissRequest = { challengeTargetFriend = null },
+            sheetState       = challengeSheetState
+        ) {
+            val f = challengeTargetFriend!!
+            LaunchedEffect(f.id) { viewModel.loadChallengePickerQuizzes() }
+            ChallengeFriendQuizSheetContent(
+                fixedFriend   = f,
+                friends       = emptyList(),
+                quizzes       = uiState.challengePickerQuizzes,
+                isLoading     = uiState.challengePickerLoading,
+                onDismiss     = { challengeTargetFriend = null },
+                onSendChallenge = { fid, qid, title ->
+                    viewModel.sendChallenge(fid, qid, title)
+                }
+            )
+        }
     }
 
     Scaffold(
@@ -201,7 +236,8 @@ fun FriendsScreen(
                         when (selectedTab) {
                             0 -> FriendsTab(
                                 friends = filteredFriends,
-                                onDelete = { friend -> viewModel.removeFriend(friend.id) }
+                                onDelete = { friend -> viewModel.removeFriend(friend.id) },
+                                onChallengeFriend = { challengeTargetFriend = it }
                             )
                             1 -> IncomingRequestsTab(
                                 requests = filteredIncoming,
@@ -339,7 +375,8 @@ private fun SearchResultsList(
 @Composable
 private fun FriendsTab(
     friends: List<User>,
-    onDelete: (User) -> Unit
+    onDelete: (User) -> Unit,
+    onChallengeFriend: (User) -> Unit
 ) {
     if (friends.isEmpty()) {
         EmptyState(message = "No friends yet. Find people using the search above!")
@@ -350,7 +387,11 @@ private fun FriendsTab(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         items(friends, key = { it.id }) { friend ->
-            FriendCard(friend = friend, onDelete = { onDelete(friend) })
+            FriendCard(
+                friend     = friend,
+                onDelete   = { onDelete(friend) },
+                onChallenge = { onChallengeFriend(friend) }
+            )
         }
     }
 }
@@ -358,7 +399,8 @@ private fun FriendsTab(
 @Composable
 private fun FriendCard(
     friend: User,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onChallenge: () -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -390,12 +432,19 @@ private fun FriendCard(
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Text(
-                    text = friend.rank.name,
+                    text = friend.rank.displayName,
                     fontSize = 12.sp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            // Удалить из друзей
+            IconButton(onClick = onChallenge) {
+                Icon(
+                    imageVector = Icons.Default.Sports,
+                    contentDescription = "Challenge friend",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
             IconButton(onClick = onDelete) {
                 Icon(
                     imageVector = Icons.Default.PersonRemove,

--- a/app/src/main/java/com/example/brainracer/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/HomeScreen.kt
@@ -30,8 +30,11 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.example.brainracer.domain.entities.Challenge
+import com.example.brainracer.domain.entities.ChallengeStatus
 import com.example.brainracer.domain.entities.UserStats
 import com.example.brainracer.ui.components.BottomBar
+import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
 import com.example.brainracer.ui.utils.QuizItem
 import com.example.brainracer.ui.viewmodels.AuthViewModel
 import com.example.brainracer.ui.viewmodels.HomeViewModel
@@ -61,16 +64,6 @@ private data class Banner(
     val actionLabel: String = "Участвовать →"
 )
 
-private data class ChallengePreview(
-    val id: Int,
-    val title: String,
-    val opponent: String,
-    val avatarInitials: String,
-    val isWin: Boolean,
-    val score: String,
-    val timeAgo: String
-)
-
 private val homeBanners = listOf(
     Banner(1, "🏆 Турнир Чемпионов", "Призовой фонд 5000 монет",
         listOf(Color(0xFF667EEA), Color(0xFF764BA2))),
@@ -79,14 +72,6 @@ private val homeBanners = listOf(
     Banner(3, "🎯 Новая категория", "Искусство и Культура",
         listOf(Color(0xFF4facfe), Color(0xFF00f2fe)))
 )
-
-private val sampleChallenges = listOf(
-    ChallengePreview(1, "Дуэль", "Алексей К.", "AK", true,  "15:12", "2 мин назад"),
-    ChallengePreview(2, "Блиц",  "Мария С.",   "MS", false, "18:20", "1 час назад"),
-    ChallengePreview(3, "Дуэль", "Дмитрий В.", "DV", true,  "10:8",  "3 часа назад")
-)
-
-// ══════════════════════════════════════════════════════════════════════════════
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -131,7 +116,42 @@ fun HomeScreen(
         }
     }
 
+    var showChallengeSheet by remember { mutableStateOf(false) }
+    val challengeSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    LaunchedEffect(uiState.challengeSentMessage) {
+        uiState.challengeSentMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            homeViewModel.consumeChallengeSentMessage()
+            showChallengeSheet = false
+        }
+    }
+
+    LaunchedEffect(showChallengeSheet) {
+        if (showChallengeSheet) homeViewModel.loadChallengePickerData()
+    }
+
     val tabQuizzes = uiState.quizzes.take(5)
+
+    if (showChallengeSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showChallengeSheet = false },
+            sheetState       = challengeSheetState,
+            containerColor   = BgCard,
+            contentColor     = TextPri
+        ) {
+            ChallengeFriendQuizSheetContent(
+                fixedFriend   = null,
+                friends       = uiState.friendsForChallenge,
+                quizzes       = uiState.challengePickerQuizzes,
+                isLoading     = uiState.challengePickerLoading,
+                onDismiss     = { showChallengeSheet = false },
+                onSendChallenge = { fid, qid, title ->
+                    homeViewModel.sendChallengeToFriend(fid, qid, title)
+                }
+            )
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -196,7 +216,18 @@ fun HomeScreen(
                 )
             }
 
-            item { RecentChallengesSection(sampleChallenges) }
+            item {
+                RecentChallengesSection(
+                    activeChallenges   = uiState.homeActiveChallenges,
+                    finishedChallenges = uiState.homeFinishedChallenges,
+                    currentUserId      = uiState.currentUserId,
+                    onViewAll          = { navController.navigate("challenges/${uiState.currentUserId}") },
+                    onOpenChallenge    = { ch ->
+                        navigateFromHomeToChallenge(navController, ch, uiState.currentUserId)
+                    },
+                    onNewChallenge     = { showChallengeSheet = true }
+                )
+            }
         }
     }
 }
@@ -590,8 +621,37 @@ private fun QuizRowCard(quiz: QuizItem, colorIndex: Int, onClick: () -> Unit) {
     }
 }
 
+private fun navigateFromHomeToChallenge(
+    navController: NavController,
+    ch: Challenge,
+    currentUserId: String
+) {
+    if (currentUserId.isBlank()) return
+    when {
+        ch.status == ChallengeStatus.PENDING ->
+            navController.navigate("challenges/$currentUserId")
+        ch.status == ChallengeStatus.ACCEPTED &&
+                ch.canPlay(currentUserId) &&
+                !ch.hasUserResult(currentUserId) ->
+            navController.navigate("quiz_play/${ch.quizId}?challengeId=${ch.id}")
+        else ->
+            navController.navigate("challenge_review/${ch.id}")
+    }
+}
+
 @Composable
-private fun RecentChallengesSection(challenges: List<ChallengePreview>) {
+private fun RecentChallengesSection(
+    activeChallenges: List<Challenge>,
+    finishedChallenges: List<Challenge>,
+    currentUserId: String,
+    onViewAll: () -> Unit,
+    onOpenChallenge: (Challenge) -> Unit,
+    onNewChallenge: () -> Unit
+) {
+    var tabIndex by remember { mutableIntStateOf(0) }
+    val tabLabels = listOf("Активные", "Завершённые")
+    val listShown = if (tabIndex == 0) activeChallenges else finishedChallenges
+
     Column {
         Row(
             modifier              = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
@@ -599,51 +659,220 @@ private fun RecentChallengesSection(challenges: List<ChallengePreview>) {
             verticalAlignment     = Alignment.CenterVertically
         ) {
             Text("⚔️ Последние вызовы", fontWeight = FontWeight.Bold, fontSize = 15.sp, color = TextPri)
-            TextButton(onClick = {}) { Text("История", color = AccentPurple, fontSize = 13.sp) }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onNewChallenge) {
+                    Icon(
+                        Icons.Default.Sports,
+                        contentDescription = null,
+                        tint       = AccentPurple,
+                        modifier   = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text("Вызов", color = AccentPurple, fontSize = 13.sp)
+                }
+                TextButton(onClick = onViewAll) {
+                    Text("Все вызовы", color = AccentPurple, fontSize = 13.sp)
+                }
+            }
         }
-        Spacer(Modifier.height(6.dp))
-        Column(
-            modifier            = Modifier.padding(horizontal = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+        Spacer(Modifier.height(4.dp))
+
+        TabRow(
+            selectedTabIndex = tabIndex,
+            containerColor   = BgDeep,
+            contentColor     = AccentPurple,
+            indicator = { positions ->
+                if (tabIndex < positions.size) {
+                    TabRowDefaults.SecondaryIndicator(
+                        modifier = Modifier.tabIndicatorOffset(positions[tabIndex]),
+                        color    = AccentPurple,
+                        height   = 2.dp
+                    )
+                }
+            },
+            divider = { HorizontalDivider(color = BgBorder) }
         ) {
-            challenges.forEach { ch ->
-                val winColor = if (ch.isWin) Color(0xFF43e97b) else Color(0xFFf5576c)
-                Box(
-                    modifier = Modifier.fillMaxWidth()
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(BgCard)
-                        .border(1.dp, winColor.copy(0.28f), RoundedCornerShape(16.dp))
-                ) {
-                    Row(
-                        modifier              = Modifier.fillMaxWidth().padding(14.dp),
-                        verticalAlignment     = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                            Box(
-                                modifier = Modifier.size(42.dp).clip(CircleShape)
-                                    .background(Brush.linearGradient(
-                                        listOf(Color(0xFF667EEA), Color(0xFFf093fb)))),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(ch.avatarInitials, color = Color.White,
-                                    fontWeight = FontWeight.Bold, fontSize = 13.sp)
-                            }
-                            Column {
-                                Text(ch.title, fontWeight = FontWeight.SemiBold,
-                                    fontSize = 14.sp, color = TextPri)
-                                Text("vs ${ch.opponent}", fontSize = 12.sp, color = TextSec)
-                            }
-                        }
-                        Column(horizontalAlignment = Alignment.End) {
-                            Text(ch.score, fontWeight = FontWeight.Bold,
-                                fontSize = 16.sp, color = winColor)
-                            Text(ch.timeAgo, fontSize = 11.sp, color = TextSec)
+            tabLabels.forEachIndexed { i, title ->
+                Tab(
+                    selected = tabIndex == i,
+                    onClick  = { tabIndex = i },
+                    text     = { Text(title, fontSize = 13.sp) },
+                    selectedContentColor   = AccentPurple,
+                    unselectedContentColor = TextSec
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+
+        if (listShown.isEmpty()) {
+            val (title, subtitle) = if (tabIndex == 0) {
+                "Нет активных вызовов" to "Примите вызов или бросьте вызов другу во вкладке друзей"
+            } else {
+                "Пока нет завершённых" to "Завершённые дуэли появятся здесь"
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(BgCard)
+                    .border(1.dp, BgBorder, RoundedCornerShape(16.dp))
+                    .padding(20.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text(title, color = TextPri, fontWeight = FontWeight.SemiBold, fontSize = 14.sp,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+                    Text(subtitle, color = TextSec, fontSize = 12.sp,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+                    if (tabIndex == 0) {
+                        Button(
+                            onClick     = onNewChallenge,
+                            colors      = ButtonDefaults.buttonColors(containerColor = AccentPurple),
+                            shape       = RoundedCornerShape(12.dp)
+                        ) {
+                            Icon(Icons.Default.Sports, null, Modifier.size(18.dp), Color.White)
+                            Spacer(Modifier.width(8.dp))
+                            Text("Бросить вызов", color = Color.White, fontSize = 14.sp)
                         }
                     }
                 }
             }
+            return
         }
+
+        Column(
+            modifier            = Modifier.padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            listShown.forEach { ch ->
+                HomeChallengeRow(
+                    ch            = ch,
+                    currentUserId = currentUserId,
+                    onClick       = { onOpenChallenge(ch) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeChallengeRow(
+    ch: Challenge,
+    currentUserId: String,
+    onClick: () -> Unit
+) {
+    val isChallenger = ch.challengerUserId == currentUserId
+    val opponentName = if (isChallenger) ch.challengedNickname else ch.challengerNickname
+    val myResult     = if (isChallenger) ch.challengerResult else ch.challengedResult
+    val oppResult    = if (isChallenger) ch.challengedResult else ch.challengerResult
+
+    val (statusColor, statusLabel) = when {
+        ch.status == ChallengeStatus.PENDING && !isChallenger ->
+            Color(0xFFFFA726) to "Входящий"
+        ch.status == ChallengeStatus.PENDING && isChallenger ->
+            Color(0xFFFFA726) to "В обработке"
+        ch.status == ChallengeStatus.ACCEPTED ->
+            Color(0xFF4facfe) to when {
+                ch.hasUserResult(currentUserId) -> "Пройдено"
+                else -> "Нужно пройти"
+            }
+        ch.status == ChallengeStatus.COMPLETED -> {
+            val isDraw = ch.isDraw || ch.winnerId == "draw"
+            val isWin  = !isDraw && ch.winnerId == currentUserId
+            when {
+                isDraw -> Color(0xFFFFA726) to "Ничья"
+                isWin  -> Color(0xFF3ECFA3) to "Победа"
+                else   -> Color(0xFFEA5C7E) to "Поражение"
+            }
+        }
+        else -> Color(0xFF8B8AAE) to ch.status.name
+    }
+
+    val isFinishedRow = ch.status == ChallengeStatus.COMPLETED
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(if (isFinishedRow) 0.82f else 1f)
+            .clip(RoundedCornerShape(16.dp))
+            .background(BgCard)
+            .border(1.dp, statusColor.copy(0.3f), RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier              = Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier              = Modifier.weight(1f)
+            ) {
+                Box(
+                    modifier = Modifier.size(42.dp).clip(CircleShape)
+                        .background(Brush.linearGradient(
+                            listOf(Color(0xFF667EEA), Color(0xFFf093fb)))),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(opponentName.take(2).uppercase(),
+                        color = Color.White, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("vs $opponentName", fontWeight = FontWeight.SemiBold,
+                        fontSize = 14.sp, color = TextPri,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    Text(ch.quizTitle, fontSize = 11.sp, color = TextSec,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+            }
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                if (ch.status == ChallengeStatus.COMPLETED) {
+                    Text(
+                        "${myResult?.score ?: 0} : ${oppResult?.score ?: 0}",
+                        fontWeight = FontWeight.Bold, fontSize = 14.sp, color = TextPri
+                    )
+                }
+                if (ch.status == ChallengeStatus.ACCEPTED) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        HomeProgressDot(played = myResult != null, label = "Вы")
+                        HomeProgressDot(played = oppResult != null, label = opponentName.split(" ").first())
+                    }
+                }
+                Surface(shape = RoundedCornerShape(6.dp), color = statusColor.copy(.15f)) {
+                    Text(
+                        statusLabel,
+                        modifier   = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                        fontSize   = 10.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color      = statusColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeProgressDot(played: Boolean, label: String) {
+    val color = if (played) Color(0xFF3ECFA3) else Color(0xFF8B8AAE)
+    Row(
+        verticalAlignment     = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp)
+    ) {
+        Icon(
+            imageVector = if (played) Icons.Default.CheckCircle else Icons.Default.HourglassEmpty,
+            contentDescription = null,
+            tint     = color,
+            modifier = Modifier.size(11.dp)
+        )
+        Text(label, fontSize = 10.sp, color = color, fontWeight = FontWeight.Medium)
     }
 }

--- a/app/src/main/java/com/example/brainracer/ui/screens/QuizPlayScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/QuizPlayScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.activity.compose.BackHandler
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.brainracer.domain.entities.LevelSystem
@@ -84,18 +86,35 @@ private fun resultLevel(pct: Int) = when {
 fun QuizPlayScreen(
     quizId: String,
     navController: NavController,
+    challengeId: String? = null,
     quizViewModel: QuizViewModel = viewModel()
 ) {
     val uiState by quizViewModel.uiState.collectAsState()
 
-    LaunchedEffect(quizId) { quizViewModel.loadQuiz(quizId) }
+    LaunchedEffect(quizId, challengeId) { quizViewModel.loadQuiz(quizId, challengeId) }
+
+    var challengeIntroAcknowledged by rememberSaveable(quizId, challengeId) {
+        mutableStateOf(false)
+    }
 
     when {
         uiState.isLoading -> LoadingScreen()
         uiState.errorMessage != null ->
             ErrorScreen(uiState.errorMessage!!) { navController.popBackStack() }
+        !challengeId.isNullOrBlank() && !challengeIntroAcknowledged -> {
+            BackHandler { navController.popBackStack() }
+            ChallengeDuelIntroScreen(
+                quizTitle       = uiState.quizTitle.ifBlank { "Викторина" },
+                totalQuestions  = uiState.totalQuestions,
+                onStart         = { challengeIntroAcknowledged = true },
+                onCancel        = { navController.popBackStack() }
+            )
+        }
         uiState.showResults || uiState.isQuizCompleted -> {
-            var showReview by remember { mutableStateOf(false) }
+            var showReview by rememberSaveable(quizId, challengeId) { mutableStateOf(false) }
+            val challengeMode = !uiState.challengeId.isNullOrBlank()
+            BackHandler(enabled = challengeMode && showReview) { showReview = false }
+            BackHandler(enabled = challengeMode && !showReview) { navController.popBackStack() }
             if (showReview) {
                 AnswerReviewScreen(
                     uiState = uiState,
@@ -103,21 +122,124 @@ fun QuizPlayScreen(
                 )
             } else {
                 ResultsScreen(
-                    uiState      = uiState,
-                    onBack       = { navController.popBackStack() },
-                    onRestart    = { quizViewModel.restartQuiz() },
-                    onShowReview = { showReview = true }
+                    uiState                 = uiState,
+                    onBack                  = { navController.popBackStack() },
+                    onRestart               = { quizViewModel.restartQuiz() },
+                    onShowReview            = { showReview = true },
+                    allowRestart            = uiState.challengeId.isNullOrBlank(),
+                    challengeId             = uiState.challengeId,
+                    onOpenChallengeSummary  = uiState.challengeId?.let { cid ->
+                        { navController.navigate("challenge_review/$cid") }
+                    }
                 )
             }
-        }        uiState.question.isNotEmpty() ->
-        QuestionScreen(
-            uiState    = uiState,
-            onBack     = { navController.popBackStack() },
-            onSelect   = { quizViewModel.selectAnswer(it) },
-            onSubmit   = { quizViewModel.submitAnswer() },
-            onNext     = { quizViewModel.nextQuestion() },
-            onTimeout  = { quizViewModel.timeoutQuestion() }
-        )
+        }
+        uiState.question.isNotEmpty() ->
+            QuestionScreen(
+                uiState    = uiState,
+                onBack     = { navController.popBackStack() },
+                onSelect   = { quizViewModel.selectAnswer(it) },
+                onSubmit   = { quizViewModel.submitAnswer() },
+                onNext     = { quizViewModel.nextQuestion() },
+                onTimeout  = { quizViewModel.timeoutQuestion() }
+            )
+        else -> LoadingScreen()
+    }
+}
+
+// ── Старт дуэли (вызов) ─────────────────────────────────────────────────────
+
+@Composable
+private fun ChallengeDuelIntroScreen(
+    quizTitle: String,
+    totalQuestions: Int,
+    onStart: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Box(Modifier.fillMaxSize().background(QBg)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Icon(
+                Icons.Default.Sports,
+                contentDescription = null,
+                tint     = QPurple,
+                modifier = Modifier.size(56.dp)
+            )
+            Text(
+                "Вызов",
+                fontWeight = FontWeight.Bold,
+                fontSize   = 26.sp,
+                color      = QTextPri
+            )
+            Text(
+                quizTitle,
+                fontSize   = 16.sp,
+                color      = QTextSec,
+                textAlign  = TextAlign.Center,
+                lineHeight = 22.sp
+            )
+            Card(
+                modifier  = Modifier.fillMaxWidth(),
+                shape     = RoundedCornerShape(20.dp),
+                colors    = CardDefaults.cardColors(containerColor = QCard),
+                elevation = CardDefaults.cardElevation(0.dp),
+                border    = CardDefaults.outlinedCardBorder()
+            ) {
+                Column(
+                    modifier              = Modifier.padding(20.dp),
+                    verticalArrangement   = Arrangement.spacedBy(14.dp)
+                ) {
+                    Text(
+                        "Перед стартом",
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize   = 15.sp,
+                        color      = QTextPri
+                    )
+                    IntroBullet("Одна попытка: повторно пройти эту дуэль нельзя.")
+                    IntroBullet("Счёт станет виден обоим после того, как оба завершат викторину.")
+                    IntroBullet("По завершении дуэль окажется во вкладке «Завершённые».")
+                    if (totalQuestions > 0) {
+                        Text(
+                            "Вопросов: $totalQuestions",
+                            fontSize = 13.sp,
+                            color    = QPurple,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+            Button(
+                onClick  = onStart,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape    = RoundedCornerShape(14.dp),
+                colors   = ButtonDefaults.buttonColors(containerColor = QPurple)
+            ) {
+                Icon(Icons.Default.PlayArrow, null, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Начать викторину", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+            }
+            TextButton(onClick = onCancel) {
+                Text("Отмена", color = QTextSec, fontSize = 14.sp)
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun IntroBullet(text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment     = Alignment.Top
+    ) {
+        Text("•", color = QPurple, fontSize = 16.sp, modifier = Modifier.padding(top = 1.dp))
+        Text(text, fontSize = 13.sp, color = QTextSec, lineHeight = 18.sp, modifier = Modifier.weight(1f))
     }
 }
 
@@ -574,7 +696,10 @@ private fun ResultsScreen(
     uiState: QuizUIState,
     onBack: () -> Unit,
     onRestart: () -> Unit,
-    onShowReview: () -> Unit
+    onShowReview: () -> Unit,
+    allowRestart: Boolean = true,
+    challengeId: String? = null,
+    onOpenChallengeSummary: (() -> Unit)? = null
 ) {
     val accuracyPct = if (uiState.totalQuestions > 0)
         (uiState.correctAnswers * 100) / uiState.totalQuestions else 0
@@ -679,15 +804,38 @@ private fun ResultsScreen(
                 XpCard(uiState = uiState, xpProgressAnimated = xpProgressAnimated)
             }
 
-            Button(
-                onClick  = onRestart,
-                modifier = Modifier.fillMaxWidth().height(52.dp),
-                shape    = RoundedCornerShape(14.dp),
-                colors   = ButtonDefaults.buttonColors(containerColor = QPurple)
-            ) {
-                Icon(Icons.Default.Refresh, null, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(8.dp))
-                Text("Пройти снова", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+            if (allowRestart) {
+                Button(
+                    onClick  = onRestart,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                    shape    = RoundedCornerShape(14.dp),
+                    colors   = ButtonDefaults.buttonColors(containerColor = QPurple)
+                ) {
+                    Icon(Icons.Default.Refresh, null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Пройти снова", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+                }
+            } else {
+                Text(
+                    "В режиме вызова повторное прохождение недоступно.",
+                    fontSize = 13.sp,
+                    color = QTextSec,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            if (!challengeId.isNullOrBlank() && onOpenChallengeSummary != null) {
+                Button(
+                    onClick  = onOpenChallengeSummary,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                    shape    = RoundedCornerShape(14.dp),
+                    colors   = ButtonDefaults.buttonColors(containerColor = QGreen)
+                ) {
+                    Icon(Icons.Default.EmojiEvents, null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Итоги вызова", fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+                }
             }
 
             // Кнопка разбора — показывается только если есть что разбирать


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new navigation paths and challenge-mode behavior in `QuizPlayScreen`, which can affect back navigation and completion flows if route/viewmodel wiring is inconsistent.
> 
> **Overview**
> **Adds a full challenges UI flow.** Introduces `ChallengesScreen` with incoming/active/completed tabs, badge counts, and in-place actions (accept/decline/cancel, play, and round review navigation).
> 
> **Adds a reusable challenge picker bottom sheet** (`ChallengeFriendQuizSheetContent`) and wires it into `HomeScreen`, `FriendsScreen`, and `ChallengesScreen` to send a challenge by selecting a friend and quiz (or a fixed friend).
> 
> **Adds challenge-specific play/review UX.** `QuizPlayScreen` now supports `challengeId` mode with an intro screen, restart disabled for challenges, adjusted back handling, and a CTA to open `challenge_review`; new `ChallengeRoundReviewScreen` compares answers, timing, and shows score/status (including hiding scores until both finish).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9101ee8aa210e68a69d69dd69bf0c55a2ced7680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->