### PR TITLE
Обновил визуал

### DIFF
--- a/app/src/main/java/com/example/brainracer/ui/screens/ChallendgeRoundReviewScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ChallendgeRoundReviewScreen.kt
@@ -28,21 +28,8 @@ import com.example.brainracer.domain.entities.Challenge
 import com.example.brainracer.domain.entities.ChallengeStatus
 import com.example.brainracer.domain.entities.Question
 import com.example.brainracer.domain.entities.UserAnswer
+import com.example.brainracer.ui.theme.LocalBrainRacerExtendedColors
 import com.google.firebase.auth.FirebaseAuth
-
-// ─── Палитра (та же что в ChallengesScreen) ──────────────────────────────────
-private val RBg      = Color(0xFF0F0F1A)
-private val RCard    = Color(0xFF1A1A2E)
-private val RBorder  = Color(0xFF2A2A3E)
-private val RPurple  = Color(0xFF667EEA)
-private val RGreen   = Color(0xFF3ECFA3)
-private val RRed     = Color(0xFFEA5C7E)
-private val ROrange  = Color(0xFFFFA726)
-private val RGold    = Color(0xFFFFD700)
-private val RTextPri = Color(0xFFFFFFFF)
-private val RTextSec = Color(0xFF8B8AAE)
-
-// ══════════════════════════════════════════════════════════════════════════════
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,33 +61,33 @@ fun ChallengeRoundReviewScreen(
     }
 
     Scaffold(
-        containerColor      = RBg,
+        containerColor      = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets.systemBars,
         topBar = {
             TopAppBar(
                 title = {
-                    Text("Разбор раунда", color = RTextPri,
+                    Text("Разбор раунда", color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.Bold, fontSize = 16.sp)
                 },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Box(Modifier.size(36.dp).clip(CircleShape).background(RCard),
+                        Box(Modifier.size(36.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surface),
                             contentAlignment = Alignment.Center) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, null,
-                                tint = RTextPri, modifier = Modifier.size(18.dp))
+                                tint = MaterialTheme.colorScheme.onSurface, modifier = Modifier.size(18.dp))
                         }
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = RBg)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }
     ) { padding ->
         when {
             isLoading -> Box(Modifier.fillMaxSize(), Alignment.Center) {
-                CircularProgressIndicator(color = RPurple)
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
             error != null -> Box(Modifier.fillMaxSize(), Alignment.Center) {
-                Text(error!!, color = RRed, textAlign = TextAlign.Center,
+                Text(error!!, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center,
                     modifier = Modifier.padding(24.dp))
             }
             challenge != null -> {
@@ -173,16 +160,16 @@ private fun ScoreHeader(
     val (resultLabel, resultColor) = when {
         !finished -> when {
             myResult == null && opponentResult == null ->
-                "Вызов принят" to RTextSec
+                "Вызов принят" to MaterialTheme.colorScheme.onSurfaceVariant
             myResult != null && opponentResult == null ->
-                "Ожидаем соперника" to ROrange
+                "Ожидаем соперника" to LocalBrainRacerExtendedColors.current.statusOrange
             myResult == null && opponentResult != null ->
-                "Ваш ход" to RPurple
-            else -> "В процессе" to RTextSec
+                "Ваш ход" to MaterialTheme.colorScheme.primary
+            else -> "В процессе" to MaterialTheme.colorScheme.onSurfaceVariant
         }
-        isDraw -> "Ничья" to ROrange
-        isWin  -> "Победа" to RGreen
-        else   -> "Поражение" to RRed
+        isDraw -> "Ничья" to LocalBrainRacerExtendedColors.current.statusOrange
+        isWin  -> "Победа" to LocalBrainRacerExtendedColors.current.detailGreen
+        else   -> "Поражение" to MaterialTheme.colorScheme.error
     }
 
     val myScoreDisplay     = myResult?.score
@@ -193,7 +180,7 @@ private fun ScoreHeader(
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(20.dp),
-        colors    = CardDefaults.cardColors(containerColor = RCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp)
     ) {
         Column(
@@ -220,7 +207,7 @@ private fun ScoreHeader(
                     isWinner  = isWin,
                     hideScore = hideMyScore
                 )
-                Text(":", fontSize = 28.sp, fontWeight = FontWeight.Bold, color = RTextSec)
+                Text(":", fontSize = 28.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 val oppWins = finished && !isDraw && !isWin
                 PlayerScoreColumn(
                     name      = opponentName.split(" ").first(),
@@ -242,19 +229,19 @@ private fun PlayerScoreColumn(
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(name, fontSize = 13.sp, color = RTextSec)
+        Text(name, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(
             if (hideScore) "—" else "${score ?: 0}",
             fontWeight = FontWeight.Bold,
             fontSize   = 32.sp,
             color      = when {
-                hideScore -> RTextSec
-                isWinner  -> RGreen
-                else      -> RTextPri
+                hideScore -> MaterialTheme.colorScheme.onSurfaceVariant
+                isWinner  -> LocalBrainRacerExtendedColors.current.detailGreen
+                else      -> MaterialTheme.colorScheme.onSurface
             }
         )
         if (isWinner) {
-            Icon(Icons.Default.EmojiEvents, null, tint = RGold, modifier = Modifier.size(18.dp))
+            Icon(Icons.Default.EmojiEvents, null, tint = LocalBrainRacerExtendedColors.current.difficultyExpert, modifier = Modifier.size(18.dp))
         }
     }
 }
@@ -273,7 +260,7 @@ private fun QuestionComparisonCard(
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(18.dp),
-        colors    = CardDefaults.cardColors(containerColor = RCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp),
         border    = CardDefaults.outlinedCardBorder()
     ) {
@@ -282,12 +269,12 @@ private fun QuestionComparisonCard(
             // Номер + текст вопроса
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.Top) {
-                Surface(shape = RoundedCornerShape(6.dp), color = RPurple.copy(.15f)) {
+                Surface(shape = RoundedCornerShape(6.dp), color = MaterialTheme.colorScheme.primary.copy(.15f)) {
                     Text("${index + 1}", modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                        fontSize = 11.sp, fontWeight = FontWeight.Bold, color = RPurple)
+                        fontSize = 11.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
                 }
                 Text(question.questionText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold,
-                    color = RTextPri, lineHeight = 20.sp, modifier = Modifier.weight(1f))
+                    color = MaterialTheme.colorScheme.onSurface, lineHeight = 20.sp, modifier = Modifier.weight(1f))
             }
 
             // Варианты ответов
@@ -299,13 +286,13 @@ private fun QuestionComparisonCard(
 
                 // Определяем цвет строки
                 val rowColor = when {
-                    isCorrect -> RGreen
-                    iMyChoice || isOpponentChoice -> RRed
-                    else -> RBorder
+                    isCorrect -> LocalBrainRacerExtendedColors.current.detailGreen
+                    iMyChoice || isOpponentChoice -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.outline
                 }
                 val rowBg = when {
-                    isCorrect -> RGreen.copy(.08f)
-                    iMyChoice || isOpponentChoice -> RRed.copy(.08f)
+                    isCorrect -> LocalBrainRacerExtendedColors.current.detailGreen.copy(.08f)
+                    iMyChoice || isOpponentChoice -> MaterialTheme.colorScheme.error.copy(.08f)
                     else -> Color.Transparent
                 }
 
@@ -324,27 +311,27 @@ private fun QuestionComparisonCard(
                         modifier = Modifier.width(16.dp), textAlign = TextAlign.Center)
 
                     // Текст варианта
-                    Text(optText, fontSize = 13.sp, color = RTextPri,
+                    Text(optText, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.weight(1f))
 
                     // Иконки: кто выбрал этот вариант
                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                         if (iMyChoice) {
-                            AnswerTag(myLabel, if (myAnswer?.isCorrect == true) RGreen else RRed)
+                            AnswerTag(myLabel, if (myAnswer?.isCorrect == true) LocalBrainRacerExtendedColors.current.detailGreen else MaterialTheme.colorScheme.error)
                         }
                         if (isOpponentChoice) {
-                            AnswerTag(opponentLabel, if (opponentAnswer?.isCorrect == true) RGreen else RRed)
+                            AnswerTag(opponentLabel, if (opponentAnswer?.isCorrect == true) LocalBrainRacerExtendedColors.current.detailGreen else MaterialTheme.colorScheme.error)
                         }
                         if (isCorrect) {
                             Icon(Icons.Default.CheckCircle, null,
-                                tint = RGreen, modifier = Modifier.size(15.dp))
+                                tint = LocalBrainRacerExtendedColors.current.detailGreen, modifier = Modifier.size(15.dp))
                         }
                     }
                 }
             }
 
             // Время ответа обоих игроков
-            HorizontalDivider(color = RBorder.copy(.5f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(.5f))
             Row(
                 Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly
@@ -358,8 +345,8 @@ private fun QuestionComparisonCard(
                 Row(verticalAlignment = Alignment.Top,
                     horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     Icon(Icons.Default.Lightbulb, null,
-                        tint = RGold, modifier = Modifier.size(14.dp).padding(top = 1.dp))
-                    Text(question.explanation!!, fontSize = 12.sp, color = RTextSec, lineHeight = 17.sp)
+                        tint = LocalBrainRacerExtendedColors.current.difficultyExpert, modifier = Modifier.size(14.dp).padding(top = 1.dp))
+                    Text(question.explanation!!, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, lineHeight = 17.sp)
                 }
             }
         }
@@ -377,12 +364,12 @@ private fun AnswerTag(label: String, color: Color) {
 @Composable
 private fun TimeChip(label: String, timeSpent: Int?, isCorrect: Boolean?) {
     val color = when (isCorrect) {
-        true  -> RGreen
-        false -> RRed
-        null  -> RTextSec
+        true  -> LocalBrainRacerExtendedColors.current.detailGreen
+        false -> MaterialTheme.colorScheme.error
+        null  -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(label, fontSize = 11.sp, color = RTextSec)
+        Text(label, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(
             if (timeSpent != null && timeSpent >= 0) "${timeSpent}с" else "—",
             fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = color

--- a/app/src/main/java/com/example/brainracer/ui/screens/ChallengeScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ChallengeScreen.kt
@@ -39,23 +39,11 @@ import com.example.brainracer.domain.entities.Challenge
 import com.example.brainracer.domain.entities.ChallengeStatus
 import com.example.brainracer.ui.components.BottomBar
 import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
+import com.example.brainracer.ui.theme.LocalBrainRacerExtendedColors
 import com.example.brainracer.ui.viewmodels.ChallengeViewModel
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
-
-// ─── Палитра ────────────────────────────────────────────────────────────────
-private val CBg      = Color(0xFF0F0F1A)
-private val CCard    = Color(0xFF1A1A2E)
-private val CBorder  = Color(0xFF2A2A3E)
-private val CPurple  = Color(0xFF667EEA)
-private val CGreen   = Color(0xFF3ECFA3)
-private val CRed     = Color(0xFFEA5C7E)
-private val COrange  = Color(0xFFFFA726)
-private val CTextPri = Color(0xFFFFFFFF)
-private val CTextSec = Color(0xFF8B8AAE)
-
-// ══════════════════════════════════════════════════════════════════════════════
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -64,7 +52,9 @@ fun ChallengesScreen(
     currentUserId: String,
     vm: ChallengeViewModel = viewModel(),
     onHomeClick: () -> Unit = {},
-    onFriendsClick: () -> Unit = {},
+    onLeaderboardClick: () -> Unit = {},
+    onChallengesClick: () -> Unit = {},
+    onQuizzesClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
     currentRoute: String = "challenges"
 ) {
@@ -105,8 +95,8 @@ fun ChallengesScreen(
         ModalBottomSheet(
             onDismissRequest = { showChallengeSheet = false },
             sheetState       = challengeSheetState,
-            containerColor   = CCard,
-            contentColor     = CTextPri
+            containerColor   = MaterialTheme.colorScheme.surface,
+            contentColor     = MaterialTheme.colorScheme.onSurface
         ) {
             ChallengeFriendQuizSheetContent(
                 fixedFriend   = null,
@@ -122,37 +112,39 @@ fun ChallengesScreen(
     }
 
     Scaffold(
-        containerColor = CBg,
+        containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
                 title = {
                     Text("Вызовы", fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp, color = CTextPri)
+                        fontSize = 20.sp, color = MaterialTheme.colorScheme.onSurface)
                 },
                 actions = {
                     TextButton(onClick = { showChallengeSheet = true }) {
                         Icon(
                             Icons.Default.Sports,
                             contentDescription = null,
-                            tint     = CPurple,
+                            tint     = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(20.dp)
                         )
                         Spacer(Modifier.width(4.dp))
-                        Text("Вызов", color = CPurple, fontSize = 14.sp,
+                        Text("Вызов", color = MaterialTheme.colorScheme.primary, fontSize = 14.sp,
                             fontWeight = FontWeight.SemiBold)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = CBg),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
                 modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
             )
         },
         bottomBar = {
             BottomBar(
-                showBar        = true,
-                currentRoute   = currentRoute,
-                onHomeClick    = onHomeClick,
-                onFriendsClick = onFriendsClick,
-                onProfileClick = onProfileClick
+                showBar              = true,
+                currentRoute         = currentRoute,
+                onHomeClick          = onHomeClick,
+                onLeaderboardClick   = onLeaderboardClick,
+                onChallengesClick    = onChallengesClick,
+                onQuizzesClick       = onQuizzesClick,
+                onProfileClick       = onProfileClick
             )
         }
     ) { padding ->
@@ -161,18 +153,18 @@ fun ChallengesScreen(
             // ── Вкладки ───────────────────────────────────────────────────
             TabRow(
                 selectedTabIndex = pagerState.currentPage,
-                containerColor   = CBg,
-                contentColor     = CPurple,
+                containerColor   = MaterialTheme.colorScheme.background,
+                contentColor     = MaterialTheme.colorScheme.primary,
                 indicator = { positions ->
                     if (pagerState.currentPage < positions.size) {
                         TabRowDefaults.Indicator(
                             modifier = Modifier.tabIndicatorOffset(positions[pagerState.currentPage])
                                 .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp)),
-                            color    = CPurple, height = 3.dp
+                            color    = MaterialTheme.colorScheme.primary, height = 3.dp
                         )
                     }
                 },
-                divider = { HorizontalDivider(color = CBorder) }
+                divider = { HorizontalDivider(color = MaterialTheme.colorScheme.outline) }
             ) {
                 tabTitles.forEachIndexed { i, title ->
                     val badge = when (i) {
@@ -183,8 +175,8 @@ fun ChallengesScreen(
                     Tab(
                         selected               = pagerState.currentPage == i,
                         onClick                = { scope.launch { pagerState.animateScrollToPage(i) } },
-                        selectedContentColor   = CPurple,
-                        unselectedContentColor = CTextSec
+                        selectedContentColor   = MaterialTheme.colorScheme.primary,
+                        unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
                     ) {
                         Row(
                             modifier = Modifier.padding(horizontal = 4.dp, vertical = 13.dp),
@@ -289,37 +281,37 @@ private fun IncomingChallengeCard(
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(18.dp),
-        colors    = CardDefaults.cardColors(containerColor = CCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             // Заголовок
             Row(verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                AvatarCircle(challenge.challengerNickname.take(2).uppercase(), CPurple, 44)
+                AvatarCircle(challenge.challengerNickname.take(2).uppercase(), MaterialTheme.colorScheme.primary, 44)
                 Column(modifier = Modifier.weight(1f)) {
                     Text(challenge.challengerNickname, fontWeight = FontWeight.Bold,
-                        fontSize = 15.sp, color = CTextPri)
-                    Text("бросает вам вызов", fontSize = 12.sp, color = CTextSec)
+                        fontSize = 15.sp, color = MaterialTheme.colorScheme.onSurface)
+                    Text("бросает вам вызов", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                Surface(shape = RoundedCornerShape(8.dp), color = COrange.copy(.15f)) {
+                Surface(shape = RoundedCornerShape(8.dp), color = LocalBrainRacerExtendedColors.current.statusOrange.copy(.15f)) {
                     Text("Новый", modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                        fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = COrange)
+                        fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = LocalBrainRacerExtendedColors.current.statusOrange)
                 }
             }
 
             // Викторина
             Row(verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Icon(Icons.Default.Quiz, null, tint = CPurple, modifier = Modifier.size(16.dp))
-                Text(challenge.quizTitle, fontSize = 13.sp, color = CTextSec,
+                Icon(Icons.Default.Quiz, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(16.dp))
+                Text(challenge.quizTitle, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
             }
 
             // Срок истечения
             Text(
                 "Истекает: ${formatTimestamp(challenge.expiresAt.seconds * 1000)}",
-                fontSize = 11.sp, color = CTextSec
+                fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
             // Кнопки
@@ -328,18 +320,18 @@ private fun IncomingChallengeCard(
                     onClick = onAccept,
                     modifier = Modifier.weight(1f),
                     shape  = RoundedCornerShape(10.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = CGreen)
+                    colors = ButtonDefaults.buttonColors(containerColor = LocalBrainRacerExtendedColors.current.detailGreen)
                 ) {
                     Icon(Icons.Default.Check, null, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
-                    Text("Принять", fontSize = 13.sp, color = Color.White)
+                    Text("Принять", fontSize = 13.sp, color = MaterialTheme.colorScheme.onPrimary)
                 }
                 OutlinedButton(
                     onClick = onDecline,
                     modifier = Modifier.weight(1f),
                     shape  = RoundedCornerShape(10.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = CRed),
-                    border = androidx.compose.foundation.BorderStroke(1.dp, CRed)
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.error)
                 ) {
                     Icon(Icons.Default.Close, null, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
@@ -415,8 +407,8 @@ private fun ActiveTab(
 @Composable
 private fun ActiveSectionHeader(title: String, subtitle: String) {
     Column(Modifier.fillMaxWidth().padding(bottom = 4.dp)) {
-        Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold, color = CTextPri)
-        Text(subtitle, fontSize = 11.sp, color = CTextSec, lineHeight = 14.sp)
+        Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+        Text(subtitle, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, lineHeight = 14.sp)
     }
 }
 
@@ -437,7 +429,7 @@ private fun ActiveChallengeCard(
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(18.dp),
-        colors    = CardDefaults.cardColors(containerColor = CCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp),
         border    = CardDefaults.outlinedCardBorder()
     ) {
@@ -445,11 +437,11 @@ private fun ActiveChallengeCard(
             // Соперник
             Row(verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                AvatarCircle(opponentName.take(2).uppercase(), CGreen, 44)
+                AvatarCircle(opponentName.take(2).uppercase(), LocalBrainRacerExtendedColors.current.detailGreen, 44)
                 Column(modifier = Modifier.weight(1f)) {
                     Text("vs $opponentName", fontWeight = FontWeight.Bold,
-                        fontSize = 15.sp, color = CTextPri)
-                    Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                        fontSize = 15.sp, color = MaterialTheme.colorScheme.onSurface)
+                    Text(challenge.quizTitle, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
@@ -474,7 +466,7 @@ private fun ActiveChallengeCard(
                     onClick  = onPlay,
                     modifier = Modifier.fillMaxWidth(),
                     shape    = RoundedCornerShape(10.dp),
-                    colors   = ButtonDefaults.buttonColors(containerColor = CPurple)
+                    colors   = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
                     Icon(Icons.Default.PlayArrow, null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(6.dp))
@@ -485,8 +477,8 @@ private fun ActiveChallengeCard(
                     onClick  = onViewRound,
                     modifier = Modifier.fillMaxWidth(),
                     shape    = RoundedCornerShape(10.dp),
-                    colors   = ButtonDefaults.outlinedButtonColors(contentColor = CPurple),
-                    border   = androidx.compose.foundation.BorderStroke(1.dp, CPurple)
+                    colors   = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+                    border   = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
                 ) {
                     Icon(Icons.Default.Analytics, null, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(6.dp))
@@ -496,7 +488,7 @@ private fun ActiveChallengeCard(
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     shape    = RoundedCornerShape(10.dp),
-                    color    = CBorder
+                    color    = MaterialTheme.colorScheme.outline
                 ) {
                     Row(
                         modifier              = Modifier.padding(12.dp),
@@ -505,11 +497,11 @@ private fun ActiveChallengeCard(
                     ) {
                         CircularProgressIndicator(
                             modifier  = Modifier.size(14.dp),
-                            color     = CTextSec,
+                            color     = MaterialTheme.colorScheme.onSurfaceVariant,
                             strokeWidth = 2.dp
                         )
                         Spacer(Modifier.width(8.dp))
-                        Text("Ждём хода соперника…", fontSize = 13.sp, color = CTextSec)
+                        Text("Ждём хода соперника…", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
             }
@@ -521,7 +513,7 @@ private fun ActiveChallengeCard(
 private fun PlayerStatusChip(label: String, played: Boolean, score: Int?) {
     Surface(
         shape  = RoundedCornerShape(8.dp),
-        color  = if (played) CGreen.copy(.12f) else CBorder
+        color  = if (played) LocalBrainRacerExtendedColors.current.detailGreen.copy(.12f) else MaterialTheme.colorScheme.outline
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
@@ -531,13 +523,13 @@ private fun PlayerStatusChip(label: String, played: Boolean, score: Int?) {
             Icon(
                 imageVector = if (played) Icons.Default.CheckCircle else Icons.Default.HourglassEmpty,
                 contentDescription = null,
-                tint = if (played) CGreen else CTextSec,
+                tint = if (played) LocalBrainRacerExtendedColors.current.detailGreen else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(13.dp)
             )
             Text(
                 text = if (score != null) "$label: $score" else label,
                 fontSize = 12.sp,
-                color    = if (played) CGreen else CTextSec,
+                color    = if (played) LocalBrainRacerExtendedColors.current.detailGreen else MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Medium
             )
         }
@@ -578,7 +570,7 @@ private fun OutgoingPendingCard(challenge: Challenge, onCancel: () -> Unit) {
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(16.dp),
-        colors    = CardDefaults.cardColors(containerColor = CCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp)
     ) {
         Row(
@@ -586,16 +578,16 @@ private fun OutgoingPendingCard(challenge: Challenge, onCancel: () -> Unit) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            AvatarCircle(challenge.challengedNickname.take(2).uppercase(), COrange, 42)
+            AvatarCircle(challenge.challengedNickname.take(2).uppercase(), LocalBrainRacerExtendedColors.current.statusOrange, 42)
             Column(modifier = Modifier.weight(1f)) {
                 Text("→ ${challenge.challengedNickname}", fontWeight = FontWeight.SemiBold,
-                    fontSize = 14.sp, color = CTextPri)
-                Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                    fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
+                Text(challenge.quizTitle, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text("В обработке · ждём соперника", fontSize = 11.sp, color = COrange)
+                Text("В обработке · ждём соперника", fontSize = 11.sp, color = LocalBrainRacerExtendedColors.current.statusOrange)
             }
             IconButton(onClick = onCancel) {
-                Icon(Icons.Default.Cancel, null, tint = CTextSec, modifier = Modifier.size(20.dp))
+                Icon(Icons.Default.Cancel, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
             }
         }
     }
@@ -617,15 +609,15 @@ private fun CompletedChallengeCard(
     val isDraw = challenge.isDraw || challenge.winnerId == "draw"
     val isWin  = !isDraw && challenge.winnerId == currentUserId
     val (resultLabel, resultColor) = when {
-        isDraw -> "Ничья" to COrange
-        isWin  -> "Победа" to CGreen
-        else   -> "Поражение" to CRed
+        isDraw -> "Ничья" to LocalBrainRacerExtendedColors.current.statusOrange
+        isWin  -> "Победа" to LocalBrainRacerExtendedColors.current.detailGreen
+        else   -> "Поражение" to MaterialTheme.colorScheme.error
     }
 
     Card(
         modifier  = Modifier.fillMaxWidth().clickable { onViewRound() },
         shape     = RoundedCornerShape(16.dp),
-        colors    = CardDefaults.cardColors(containerColor = CCard),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp),
         border    = CardDefaults.outlinedCardBorder()
     ) {
@@ -634,20 +626,20 @@ private fun CompletedChallengeCard(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            AvatarCircle(opponentName.take(2).uppercase(), CPurple, 42)
+            AvatarCircle(opponentName.take(2).uppercase(), MaterialTheme.colorScheme.primary, 42)
             Column(modifier = Modifier.weight(1f)) {
                 Text("vs $opponentName", fontWeight = FontWeight.SemiBold,
-                    fontSize = 14.sp, color = CTextPri)
-                Text(challenge.quizTitle, fontSize = 12.sp, color = CTextSec,
+                    fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
+                Text(challenge.quizTitle, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1, overflow = TextOverflow.Ellipsis)
                 Text(
                     formatTimestamp(challenge.completedAt?.seconds?.times(1000) ?: 0L),
-                    fontSize = 11.sp, color = CTextSec
+                    fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text("$myScore : $opponentScore", fontWeight = FontWeight.Bold,
-                    fontSize = 16.sp, color = CTextPri)
+                    fontSize = 16.sp, color = MaterialTheme.colorScheme.onSurface)
                 Surface(shape = RoundedCornerShape(6.dp), color = resultColor.copy(.15f)) {
                     Text(resultLabel,
                         modifier   = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
@@ -655,7 +647,7 @@ private fun CompletedChallengeCard(
                 }
             }
             Icon(Icons.AutoMirrored.Filled.ArrowForward, null,
-                tint = CTextSec, modifier = Modifier.size(16.dp))
+                tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(16.dp))
         }
     }
 }
@@ -665,7 +657,7 @@ private fun CompletedChallengeCard(
 @Composable
 private fun CenteredLoader() {
     Box(Modifier.fillMaxSize(), Alignment.Center) {
-        CircularProgressIndicator(color = CPurple)
+        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
     }
 }
 
@@ -674,12 +666,12 @@ private fun EmptyState(title: String, subtitle: String) {
     Box(Modifier.fillMaxSize().padding(32.dp), Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Box(Modifier.size(72.dp).clip(CircleShape).background(CCard), Alignment.Center) {
-                Icon(Icons.Default.Sports, null, tint = CTextSec, modifier = Modifier.size(32.dp))
+            Box(Modifier.size(72.dp).clip(CircleShape).background(MaterialTheme.colorScheme.surface), Alignment.Center) {
+                Icon(Icons.Default.Sports, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(32.dp))
             }
             Text(title, fontSize = 17.sp, fontWeight = FontWeight.SemiBold,
-                color = CTextPri, textAlign = TextAlign.Center)
-            Text(subtitle, fontSize = 14.sp, color = CTextSec, textAlign = TextAlign.Center)
+                color = MaterialTheme.colorScheme.onSurface, textAlign = TextAlign.Center)
+            Text(subtitle, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center)
         }
     }
 }

--- a/app/src/main/java/com/example/brainracer/ui/screens/ChallengeStartScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ChallengeStartScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Sports
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -46,7 +47,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -59,18 +59,10 @@ import com.example.brainracer.domain.entities.Challenge
 import com.example.brainracer.domain.entities.ChallengeStatus
 import com.example.brainracer.domain.entities.Quiz
 import com.example.brainracer.domain.entities.QuizDifficulty
+import com.example.brainracer.ui.theme.LocalBrainRacerExtendedColors
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.launch
 import java.util.Locale
-
-private val SBg = Color(0xFF0F0F1A)
-private val SCard = Color(0xFF1A1A2E)
-private val SBorder = Color(0xFF2A2A3E)
-private val SPurple = Color(0xFF667EEA)
-private val SGreen = Color(0xFF3ECFA3)
-private val SRed = Color(0xFFEA5C7E)
-private val STextPri = Color(0xFFFFFFFF)
-private val STextSec = Color(0xFF8B8AAE)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -132,29 +124,29 @@ fun ChallengeStartScreen(
     }
 
     Scaffold(
-        containerColor = SBg,
+        containerColor = MaterialTheme.colorScheme.background,
         contentWindowInsets = WindowInsets.systemBars,
         topBar = {
             TopAppBar(
                 title = {
                     Text(
                         "Вызов",
-                        color = STextPri,
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.Bold,
                         fontSize = 18.sp
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = STextPri)
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = MaterialTheme.colorScheme.onSurface)
                     }
                 },
                 actions = {
                     TextButton(onClick = { navigateHomeRoot() }) {
-                        Text("Главная", color = SPurple, fontSize = 14.sp)
+                        Text("Главная", color = MaterialTheme.colorScheme.primary, fontSize = 14.sp)
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = SBg)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }
     ) { padding ->
@@ -165,7 +157,7 @@ fun ChallengeStartScreen(
                     .padding(padding),
                 contentAlignment = Alignment.Center
             ) {
-                CircularProgressIndicator(color = SPurple)
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
             }
             error != null -> Box(
                 Modifier
@@ -174,7 +166,7 @@ fun ChallengeStartScreen(
                     .padding(24.dp),
                 contentAlignment = Alignment.Center
             ) {
-                Text(error!!, color = SRed, fontSize = 15.sp, textAlign = TextAlign.Center)
+                Text(error!!, color = MaterialTheme.colorScheme.error, fontSize = 15.sp, textAlign = TextAlign.Center)
             }
             challenge == null || quiz == null -> Box(
                 Modifier
@@ -182,7 +174,7 @@ fun ChallengeStartScreen(
                     .padding(padding),
                 contentAlignment = Alignment.Center
             ) {
-                Text("Нет данных", color = STextSec)
+                Text("Нет данных", color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             else -> {
                 val ch = challenge!!
@@ -197,7 +189,7 @@ fun ChallengeStartScreen(
                             .padding(24.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text("Этот вызов не для вашего аккаунта", color = SRed, textAlign = TextAlign.Center)
+                        Text("Этот вызов не для вашего аккаунта", color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
                     }
                 } else {
                     ChallengeStartContent(
@@ -271,7 +263,7 @@ private fun ChallengeStartContent(
         Icon(
             Icons.Default.Sports,
             contentDescription = null,
-            tint = SPurple,
+            tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(top = 8.dp)
@@ -280,14 +272,14 @@ private fun ChallengeStartContent(
             quiz.title.ifBlank { challenge.quizTitle },
             fontWeight = FontWeight.Bold,
             fontSize = 22.sp,
-            color = STextPri,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()
         )
         Text(
             "Соперник: $opponentName",
             fontSize = 14.sp,
-            color = SPurple,
+            color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.Medium,
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center
@@ -296,7 +288,7 @@ private fun ChallengeStartContent(
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(20.dp),
-            colors = CardDefaults.cardColors(containerColor = SCard),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
             elevation = CardDefaults.cardElevation(0.dp),
             border = CardDefaults.outlinedCardBorder()
         ) {
@@ -305,11 +297,11 @@ private fun ChallengeStartContent(
                 verticalArrangement = Arrangement.spacedBy(14.dp)
             ) {
                 MetaRow("Описание", quiz.description.ifBlank { "—" })
-                HorizontalDivider(color = SBorder)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
                 MetaRow("Категория", quiz.categoryId.ifBlank { "—" })
-                HorizontalDivider(color = SBorder)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
                 MetaRow("Сложность", quiz.difficulty.labelRu())
-                HorizontalDivider(color = SBorder)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
                 MetaRow(
                     label = "Рейтинг",
                     value = ratingLine(quiz),
@@ -317,12 +309,12 @@ private fun ChallengeStartContent(
                         Icon(
                             Icons.Default.Star,
                             null,
-                            tint = Color(0xFFFFD700),
+                            tint = LocalBrainRacerExtendedColors.current.difficultyExpert,
                             modifier = Modifier.padding(end = 6.dp)
                         )
                     }
                 )
-                HorizontalDivider(color = SBorder)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
                 MetaRow(
                     label = "Время прохождения",
                     value = formatDurationSeconds(quiz.totalTime),
@@ -330,12 +322,12 @@ private fun ChallengeStartContent(
                         Icon(
                             Icons.Default.Schedule,
                             null,
-                            tint = STextSec,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(end = 6.dp)
                         )
                     }
                 )
-                HorizontalDivider(color = SBorder)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline)
                 MetaRow("Вопросов", "${quiz.questionCount}")
             }
         }
@@ -345,7 +337,7 @@ private fun ChallengeStartContent(
         if (!actionError.isNullOrBlank()) {
             Text(
                 actionError!!,
-                color = SRed,
+                color = MaterialTheme.colorScheme.error,
                 fontSize = 13.sp,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
@@ -358,7 +350,7 @@ private fun ChallengeStartContent(
                     Text(
                         "Примите вызов, чтобы перейти к викторине.",
                         fontSize = 13.sp,
-                        color = STextSec,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -369,12 +361,12 @@ private fun ChallengeStartContent(
                             .fillMaxWidth()
                             .height(52.dp),
                         shape = RoundedCornerShape(14.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = SPurple)
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                     ) {
                         if (busy) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(22.dp),
-                                color = Color.White,
+                                color = MaterialTheme.colorScheme.onPrimary,
                                 strokeWidth = 2.dp
                             )
                         } else {
@@ -389,14 +381,14 @@ private fun ChallengeStartContent(
                             .height(48.dp),
                         shape = RoundedCornerShape(14.dp)
                     ) {
-                        Text("Отклонить", color = SRed)
+                        Text("Отклонить", color = MaterialTheme.colorScheme.error)
                     }
                 }
                 else -> {
                     Text(
                         "Ожидайте, пока соперник примет вызов.",
                         fontSize = 14.sp,
-                        color = STextSec,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -407,7 +399,7 @@ private fun ChallengeStartContent(
                             .height(48.dp),
                         shape = RoundedCornerShape(14.dp)
                     ) {
-                        Text("К списку вызовов", color = STextSec)
+                        Text("К списку вызовов", color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
             }
@@ -419,7 +411,7 @@ private fun ChallengeStartContent(
                             .fillMaxWidth()
                             .height(52.dp),
                         shape = RoundedCornerShape(14.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = SPurple)
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                     ) {
                         Text("Начать викторину", fontWeight = FontWeight.SemiBold)
                     }
@@ -428,7 +420,7 @@ private fun ChallengeStartContent(
                     Text(
                         "Вы уже прошли эту викторину в рамках вызова.",
                         fontSize = 14.sp,
-                        color = STextSec,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -439,13 +431,13 @@ private fun ChallengeStartContent(
                             .height(48.dp),
                         shape = RoundedCornerShape(14.dp)
                     ) {
-                        Text("К вызовам", color = STextSec)
+                        Text("К вызовам", color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 }
                 else -> {
                     Text(
                         "Вызов недоступен (срок или статус).",
-                        color = STextSec,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontSize = 14.sp,
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center
@@ -461,13 +453,13 @@ private fun ChallengeStartContent(
                         .height(48.dp),
                     shape = RoundedCornerShape(14.dp)
                 ) {
-                    Text("К списку вызовов", color = STextSec)
+                    Text("К списку вызовов", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
             else -> {
                 Text(
                     "Этот вызов больше не активен.",
-                    color = STextSec,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = 14.sp,
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center
@@ -479,7 +471,7 @@ private fun ChallengeStartContent(
                         .height(48.dp),
                     shape = RoundedCornerShape(14.dp)
                 ) {
-                    Text("К вызовам", color = STextSec)
+                    Text("К вызовам", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
@@ -493,13 +485,13 @@ private fun MetaRow(
     valueIcon: (@Composable () -> Unit)? = null
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(label, fontSize = 12.sp, color = STextSec, fontWeight = FontWeight.Medium)
+        Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = FontWeight.Medium)
         Row(verticalAlignment = Alignment.CenterVertically) {
             valueIcon?.invoke()
             Text(
                 value,
                 fontSize = 15.sp,
-                color = STextPri,
+                color = MaterialTheme.colorScheme.onSurface,
                 lineHeight = 20.sp
             )
         }
@@ -524,10 +516,10 @@ private fun StatusBlock(challenge: Challenge, currentUserId: String) {
         Box(
             Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .background(SBorder)
+                .background(MaterialTheme.colorScheme.outline)
                 .padding(horizontal = 12.dp, vertical = 6.dp)
         ) {
-            Text(label, fontSize = 12.sp, color = STextPri, fontWeight = FontWeight.SemiBold)
+            Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.SemiBold)
         }
     }
 }
@@ -547,19 +539,19 @@ private fun CompletedSummary(challenge: Challenge, currentUserId: String) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = SCard.copy(alpha = 0.6f))
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f))
     ) {
         Column(
             Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Text("Итог дуэли", fontWeight = FontWeight.Bold, color = STextPri, fontSize = 16.sp)
+            Text("Итог дуэли", fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp)
             if (challenge.isDraw || challenge.winnerId == "draw") {
-                Text("Ничья", color = STextSec, fontSize = 14.sp)
+                Text("Ничья", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 14.sp)
             } else if (challenge.winnerId == currentUserId) {
-                Text("Победа", color = SGreen, fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
+                Text("Победа", color = LocalBrainRacerExtendedColors.current.detailGreen, fontWeight = FontWeight.SemiBold, fontSize = 15.sp)
             } else if (challenge.winnerId != null) {
-                Text("Поражение", color = STextSec, fontSize = 15.sp)
+                Text("Поражение", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 15.sp)
             }
             val myScore = my?.score
             val oppScore = opp?.score
@@ -567,7 +559,7 @@ private fun CompletedSummary(challenge: Challenge, currentUserId: String) {
                 Text(
                     "Ваш счёт: ${myScore ?: "—"} · Соперник: ${oppScore ?: "—"}",
                     fontSize = 13.sp,
-                    color = STextSec
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/java/com/example/brainracer/ui/screens/FriendListScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/FriendListScreen.kt
@@ -1,10 +1,12 @@
 package com.example.brainracer.ui.screens
 
+import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -21,12 +23,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.example.brainracer.domain.entities.User
 import com.example.brainracer.ui.components.BottomBar
 import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
@@ -41,9 +43,12 @@ import com.example.brainracer.ui.viewmodels.FriendsViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FriendsScreen(
+    navController: NavController,
     viewModel: FriendsViewModel = viewModel(),
     onHomeClick: () -> Unit = {},
-    onFriendsClick: () -> Unit = {},
+    onLeaderboardClick: () -> Unit = {},
+    onChallengesClick: () -> Unit = {},
+    onQuizzesClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
     currentRoute: String = "friends"
 ) {
@@ -68,7 +73,7 @@ fun FriendsScreen(
     // так мы избегаем лишних emit-ов в ViewModel при каждом нажатии клавиши.
     var searchQuery by remember { mutableStateOf(uiState.searchQuery) }
 
-    val tabs = listOf("My friends", "Incoming", "Outgoing")
+    val tabs = listOf("Мои друзья", "Входящие", "Исходящие")
 
     // Фильтрация на стороне UI (ViewModel уже возвращает полные списки).
     val filteredFriends = uiState.friends.filter {
@@ -106,8 +111,7 @@ fun FriendsScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = "Friends",
-                        fontFamily = FontFamily.SansSerif,
+                        text = "Друзья",
                         fontWeight = FontWeight.Bold,
                         fontSize = 22.sp
                     )
@@ -121,11 +125,13 @@ fun FriendsScreen(
         },
         bottomBar = {
             BottomBar(
-                showBar = true,
-                currentRoute = currentRoute,
-                onHomeClick = onHomeClick,
-                onFriendsClick = onFriendsClick,
-                onProfileClick = onProfileClick
+                showBar              = true,
+                currentRoute         = currentRoute,
+                onHomeClick          = onHomeClick,
+                onLeaderboardClick   = onLeaderboardClick,
+                onChallengesClick    = onChallengesClick,
+                onQuizzesClick       = onQuizzesClick,
+                onProfileClick       = onProfileClick
             )
         },
         containerColor = MaterialTheme.colorScheme.background
@@ -149,11 +155,11 @@ fun FriendsScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                placeholder = { Text("Find users…") },
+                placeholder = { Text("Найти пользователей…") },
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = "Search",
+                        contentDescription = "Поиск",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 },
@@ -169,7 +175,7 @@ fun FriendsScreen(
                         }) {
                             Icon(
                                 imageVector = Icons.Default.Clear,
-                                contentDescription = "Clear",
+                                contentDescription = "Очистить",
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
@@ -187,7 +193,8 @@ fun FriendsScreen(
             if (uiState.isSearching && uiState.searchResults.isNotEmpty()) {
                 SearchResultsList(
                     results = uiState.searchResults,
-                    onSendRequest = { user -> viewModel.sendFriendRequest(user.id) }
+                    onSendRequest = { user -> viewModel.sendFriendRequest(user.id) },
+                    onOpenProfile = { user -> navController.navigate("profile/${user.id}") }
                 )
             } else {
 
@@ -213,7 +220,7 @@ fun FriendsScreen(
                             selected = selectedTab == index,
                             onClick = { selectedTab = index },
                             text = {
-                                // На вкладке «Incoming» показываем счётчик
+                                // На вкладке «Входящие» показываем счётчик
                                 if (index == 1 && incomingBadge > 0) {
                                     Row(verticalAlignment = Alignment.CenterVertically) {
                                         Text(title, fontSize = 13.sp)
@@ -237,7 +244,10 @@ fun FriendsScreen(
                             0 -> FriendsTab(
                                 friends = filteredFriends,
                                 onDelete = { friend -> viewModel.removeFriend(friend.id) },
-                                onChallengeFriend = { challengeTargetFriend = it }
+                                onChallengeFriend = { challengeTargetFriend = it },
+                                onOpenProfile = { friend ->
+                                    navController.navigate("profile/${friend.id}")
+                                }
                             )
                             1 -> IncomingRequestsTab(
                                 requests = filteredIncoming,
@@ -246,12 +256,18 @@ fun FriendsScreen(
                                 },
                                 onDecline = { req ->
                                     viewModel.declineFriendRequest(req.id)
+                                },
+                                onOpenProfile = { senderId ->
+                                    navController.navigate("profile/$senderId")
                                 }
                             )
                             2 -> OutgoingRequestsTab(
                                 requests = filteredOutgoing,
                                 onCancel = { req ->
                                     viewModel.cancelOutgoingRequest(req.id)
+                                },
+                                onOpenProfile = { receiverId ->
+                                    navController.navigate("profile/$receiverId")
                                 }
                             )
                         }
@@ -264,7 +280,28 @@ fun FriendsScreen(
                     color = MaterialTheme.colorScheme.surface
                 ) {
                     Button(
-                        onClick = { /* TODO: поделиться ссылкой */ },
+                        onClick = {
+                            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_SUBJECT, "Brain Racer")
+                                putExtra(
+                                    Intent.EXTRA_TEXT,
+                                    "Присоединяйся ко мне в Brain Racer — викторины и дуэли с друзьями!\n" +
+                                            "Приложение: com.example.brainracer"
+                                )
+                            }
+                            try {
+                                context.startActivity(
+                                    Intent.createChooser(shareIntent, "Пригласить друзей")
+                                )
+                            } catch (_: Exception) {
+                                Toast.makeText(
+                                    context,
+                                    "Не удалось открыть окно отправки",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        },
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 12.dp)
@@ -281,7 +318,7 @@ fun FriendsScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = "Invite friends",
+                            text = "Пригласить друзей",
                             fontSize = 16.sp,
                             fontWeight = FontWeight.SemiBold
                         )
@@ -295,7 +332,7 @@ fun FriendsScreen(
                     modifier = Modifier.padding(16.dp),
                     action = {
                         TextButton(onClick = { viewModel.loadFriends() }) {
-                            Text("Retry")
+                            Text("Повторить")
                         }
                     }
                 ) {
@@ -313,7 +350,8 @@ fun FriendsScreen(
 @Composable
 private fun SearchResultsList(
     results: List<User>,
-    onSendRequest: (User) -> Unit
+    onSendRequest: (User) -> Unit,
+    onOpenProfile: (User) -> Unit
 ) {
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
@@ -335,29 +373,36 @@ private fun SearchResultsList(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     // Аватар-инициалы из никнейма
-                    AvatarCircle(
-                        initials = user.nickname.take(2).uppercase(),
-                        color = MaterialTheme.colorScheme.secondary,
-                        size = 48
-                    )
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = user.nickname,
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 15.sp,
-                            color = MaterialTheme.colorScheme.onSurface
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable { onOpenProfile(user) },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        AvatarCircle(
+                            initials = user.nickname.take(2).uppercase(),
+                            color = MaterialTheme.colorScheme.secondary,
+                            size = 48
                         )
-                        Text(
-                            text = user.rank.name,
-                            fontSize = 12.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = user.nickname,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 15.sp,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = user.rank.displayName,
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                     IconButton(onClick = { onSendRequest(user) }) {
                         Icon(
                             imageVector = Icons.Default.PersonAdd,
-                            contentDescription = "Add friend",
+                            contentDescription = "Добавить в друзья",
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(22.dp)
                         )
@@ -376,10 +421,11 @@ private fun SearchResultsList(
 private fun FriendsTab(
     friends: List<User>,
     onDelete: (User) -> Unit,
-    onChallengeFriend: (User) -> Unit
+    onChallengeFriend: (User) -> Unit,
+    onOpenProfile: (User) -> Unit
 ) {
     if (friends.isEmpty()) {
-        EmptyState(message = "No friends yet. Find people using the search above!")
+        EmptyState(message = "Пока нет друзей. Найдите людей через поиск выше.")
         return
     }
     LazyColumn(
@@ -388,9 +434,10 @@ private fun FriendsTab(
     ) {
         items(friends, key = { it.id }) { friend ->
             FriendCard(
-                friend     = friend,
-                onDelete   = { onDelete(friend) },
-                onChallenge = { onChallengeFriend(friend) }
+                friend = friend,
+                onDelete = { onDelete(friend) },
+                onChallenge = { onChallengeFriend(friend) },
+                onOpenProfile = { onOpenProfile(friend) }
             )
         }
     }
@@ -400,7 +447,8 @@ private fun FriendsTab(
 private fun FriendCard(
     friend: User,
     onDelete: () -> Unit,
-    onChallenge: () -> Unit
+    onChallenge: () -> Unit,
+    onOpenProfile: () -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -416,39 +464,55 @@ private fun FriendCard(
                 .padding(horizontal = 12.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            AvatarCircle(
-                initials = friend.nickname.take(2).uppercase(),
-                color = MaterialTheme.colorScheme.tertiary,
-                size = 48
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = friend.nickname,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 15.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurface
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onOpenProfile),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AvatarCircle(
+                    initials = friend.nickname.take(2).uppercase(),
+                    color = MaterialTheme.colorScheme.tertiary,
+                    size = 48
                 )
-                Text(
-                    text = friend.rank.displayName,
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = friend.nickname,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = friend.rank.displayName,
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
-            IconButton(onClick = onChallenge) {
+            val duelShape = RoundedCornerShape(12.dp)
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(duelShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.22f))
+                    .clickable(onClick = onChallenge),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
                     imageVector = Icons.Default.Sports,
-                    contentDescription = "Challenge friend",
+                    contentDescription = "Вызвать на дуэль",
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(22.dp)
                 )
             }
+            Spacer(modifier = Modifier.width(4.dp))
             IconButton(onClick = onDelete) {
                 Icon(
                     imageVector = Icons.Default.PersonRemove,
-                    contentDescription = "Remove friend",
+                    contentDescription = "Удалить из друзей",
                     tint = MaterialTheme.colorScheme.error,
                     modifier = Modifier.size(22.dp)
                 )
@@ -465,10 +529,11 @@ private fun FriendCard(
 private fun IncomingRequestsTab(
     requests: List<FriendRequestUi>,
     onAccept: (FriendRequestUi) -> Unit,
-    onDecline: (FriendRequestUi) -> Unit
+    onDecline: (FriendRequestUi) -> Unit,
+    onOpenProfile: (String) -> Unit
 ) {
     if (requests.isEmpty()) {
-        EmptyState(message = "No incoming requests")
+        EmptyState(message = "Нет входящих заявок")
         return
     }
     LazyColumn(
@@ -479,7 +544,8 @@ private fun IncomingRequestsTab(
             IncomingRequestCard(
                 request = request,
                 onAccept = { onAccept(request) },
-                onDecline = { onDecline(request) }
+                onDecline = { onDecline(request) },
+                onOpenProfile = { onOpenProfile(request.senderId) }
             )
         }
     }
@@ -489,7 +555,8 @@ private fun IncomingRequestsTab(
 private fun IncomingRequestCard(
     request: FriendRequestUi,
     onAccept: () -> Unit,
-    onDecline: () -> Unit
+    onDecline: () -> Unit,
+    onOpenProfile: () -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -500,7 +567,12 @@ private fun IncomingRequestCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onOpenProfile),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 AvatarCircle(
                     initials = request.senderName.take(2).uppercase(),
                     color = MaterialTheme.colorScheme.secondary,
@@ -515,7 +587,7 @@ private fun IncomingRequestCard(
                         color = MaterialTheme.colorScheme.onSurface
                     )
                     Text(
-                        text = "Wants to be your friend",
+                        text = "Хочет добавиться в друзья",
                         fontSize = 12.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -539,7 +611,7 @@ private fun IncomingRequestCard(
                         modifier = Modifier.size(16.dp)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text("Accept", fontSize = 13.sp)
+                    Text("Принять", fontSize = 13.sp)
                 }
                 // Отклонить
                 OutlinedButton(
@@ -557,7 +629,7 @@ private fun IncomingRequestCard(
                         modifier = Modifier.size(16.dp)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text("Decline", fontSize = 13.sp)
+                    Text("Отклонить", fontSize = 13.sp)
                 }
             }
         }
@@ -571,10 +643,11 @@ private fun IncomingRequestCard(
 @Composable
 private fun OutgoingRequestsTab(
     requests: List<OutgoingRequestUi>,
-    onCancel: (OutgoingRequestUi) -> Unit
+    onCancel: (OutgoingRequestUi) -> Unit,
+    onOpenProfile: (String) -> Unit
 ) {
     if (requests.isEmpty()) {
-        EmptyState(message = "No outgoing requests")
+        EmptyState(message = "Нет исходящих заявок")
         return
     }
     LazyColumn(
@@ -584,7 +657,8 @@ private fun OutgoingRequestsTab(
         items(requests, key = { it.id }) { request ->
             OutgoingRequestCard(
                 request = request,
-                onCancel = { onCancel(request) }
+                onCancel = { onCancel(request) },
+                onOpenProfile = { onOpenProfile(request.receiverId) }
             )
         }
     }
@@ -593,7 +667,8 @@ private fun OutgoingRequestsTab(
 @Composable
 private fun OutgoingRequestCard(
     request: OutgoingRequestUi,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    onOpenProfile: () -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -609,30 +684,37 @@ private fun OutgoingRequestCard(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            AvatarCircle(
-                initials = request.receiverName.take(2).uppercase(),
-                color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
-                size = 48
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = request.receiverName,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 15.sp,
-                    color = MaterialTheme.colorScheme.onSurface
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClick = onOpenProfile),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AvatarCircle(
+                    initials = request.receiverName.take(2).uppercase(),
+                    color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                    size = 48
                 )
-                Text(
-                    text = "Request pending…",
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = request.receiverName,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = "Заявка отправлена…",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
             // Отозвать запрос
             IconButton(onClick = onCancel) {
                 Icon(
                     imageVector = Icons.Default.Cancel,
-                    contentDescription = "Cancel request",
+                    contentDescription = "Отозвать заявку",
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(22.dp)
                 )

--- a/app/src/main/java/com/example/brainracer/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ProfileScreen.kt
@@ -1,417 +1,1033 @@
 package com.example.brainracer.ui.screens
 
+import android.net.Uri
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.brainracer.domain.entities.User
+import com.example.brainracer.domain.entities.UserRank
+import com.example.brainracer.domain.entities.UserStats
 import com.example.brainracer.ui.components.BottomBar
+import com.example.brainracer.ui.components.ChallengeFriendQuizSheetContent
+import coil.compose.AsyncImage
+import com.example.brainracer.ui.utils.ProfileAfterQuizRefresh
+import com.example.brainracer.ui.utils.AchievementUi
+import com.example.brainracer.ui.utils.PassedQuizUi
+import com.example.brainracer.ui.utils.ProfileGoalBadges
+import com.example.brainracer.ui.utils.ProfileUtils
+import com.example.brainracer.ui.utils.QuizItem
+import com.example.brainracer.ui.utils.TopicStatUi
+import com.example.brainracer.ui.theme.BrainRacerTheme
+import com.example.brainracer.ui.theme.LocalBrainRacerExtendedColors
 import com.example.brainracer.ui.viewmodels.AuthViewModel
+import com.example.brainracer.ui.viewmodels.FriendsViewModel
+import com.example.brainracer.ui.viewmodels.ProfileViewModel
+import kotlinx.coroutines.flow.collectLatest
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ProfileScreen(
+    navController: NavController,
     onNavigateToAuth: () -> Unit,
     authViewModel: AuthViewModel = viewModel(),
+    profileViewModel: ProfileViewModel = viewModel(),
+    friendsViewModel: FriendsViewModel = viewModel(),
     userId: String,
     onHomeClick: () -> Unit = {},
-    onFriendsClick: () -> Unit = {},
+    onLeaderboardClick: () -> Unit = {},
+    onChallengesClick: () -> Unit = {},
+    onQuizzesClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
     currentRoute: String = "profile",
     isOwnProfile: Boolean = true
 ) {
     val user by authViewModel.user.collectAsState()
+    val uiState by profileViewModel.uiState.collectAsState()
+    val friendsUiState by friendsViewModel.uiState.collectAsState()
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var showChallengeSheet by remember { mutableStateOf(false) }
+    val challengeSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val tabs = listOf("Созданное", "Пройденное", "Достижения")
 
-    // Демо-данные для статистики
-    val totalQuizzes = remember { 42 }
-    val winPercentage = remember { 78 }
-    val averageScore = remember { 4.3 }
-    val userLevel = remember { 7 }
-    val nextLevelProgress = remember { 0.65f }
-
-    // История последних игр
-    val recentGames = remember {
-        listOf(
-            RecentGame("Математика", "Победа", 4.5f, "2 часа назад"),
-            RecentGame("История", "Поражение", 3.2f, "1 день назад"),
-            RecentGame("Программирование", "Победа", 4.8f, "3 дня назад"),
-            RecentGame("География", "Победа", 4.1f, "5 дней назад")
-        )
+    LaunchedEffect(userId, isOwnProfile) {
+        if (isOwnProfile) ProfileAfterQuizRefresh.takePending(userId)
+        profileViewModel.loadUserProfile(userId, forceRefresh = true)
     }
 
-    // Статистика по темам
-    val topicStats = remember {
-        listOf(
-            TopicStat("Математика", 85f, Color(0xFF4CAF50)),
-            TopicStat("История", 65f, Color(0xFF2196F3)),
-            TopicStat("Программирование", 92f, Color(0xFF9C27B0)),
-            TopicStat("География", 78f, Color(0xFFFF9800)),
-            TopicStat("Биология", 54f, Color(0xFFE91E63))
-        )
+    LaunchedEffect(userId, isOwnProfile) {
+        if (!isOwnProfile) return@LaunchedEffect
+        ProfileAfterQuizRefresh.events.collectLatest { uid ->
+            if (uid == userId) {
+                profileViewModel.invalidateProfileCache()
+                profileViewModel.loadUserProfile(userId, forceRefresh = true)
+            }
+        }
     }
 
-    // Достижения
-    val achievements = remember {
-        listOf(
-            Achievement("Новичок", "Пройдите первую викторину", true),
-            Achievement("Эксперт", "Пройдите 10 викторин", true),
-            Achievement("Непобедимый", "Выиграйте 5 игр подряд", false),
-            Achievement("Мастер тем", "Получите 90%+ в 3 темах", true),
-            Achievement("Марафонец", "Играйте 7 дней подряд", false)
-        )
+    DisposableEffect(lifecycleOwner, userId, isOwnProfile) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val forceAfterQuiz = isOwnProfile && ProfileAfterQuizRefresh.takePending(userId)
+                if (forceAfterQuiz) profileViewModel.invalidateProfileCache()
+                profileViewModel.loadUserProfile(userId, forceRefresh = forceAfterQuiz)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    // Если пользователь удалён или вышел — перенаправляем на Auth
     LaunchedEffect(user) {
-        if (user == null) {
-            Toast.makeText(context, "Session expired or account deleted", Toast.LENGTH_SHORT).show()
+        if (user == null && isOwnProfile) {
+            Toast.makeText(context, "Сессия завершена или аккаунт удалён", Toast.LENGTH_SHORT).show()
             onNavigateToAuth()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_LONG).show()
+            profileViewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(friendsUiState.challengeSentMessage) {
+        friendsUiState.challengeSentMessage?.let { msg ->
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            friendsViewModel.consumeChallengeSentMessage()
+            showChallengeSheet = false
+        }
+    }
+
+    var showProfileEditSheet by remember { mutableStateOf(false) }
+    val profileEditSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var editDraftBio by remember { mutableStateOf("") }
+    var editSelectedBadges by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    LaunchedEffect(showProfileEditSheet) {
+        if (showProfileEditSheet) {
+            editDraftBio = uiState.bio
+            editSelectedBadges = uiState.interests.toSet()
+        }
+    }
+
+    val avatarPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let { profileViewModel.uploadAvatar(context, userId, it) }
+    }
+
+    if (showProfileEditSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showProfileEditSheet = false },
+            sheetState = profileEditSheetState,
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 32.dp)
+            ) {
+                Text(
+                    "Редактирование профиля",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp
+                )
+                Spacer(Modifier.height(16.dp))
+                Text("О себе", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp)
+                Spacer(Modifier.height(6.dp))
+                OutlinedTextField(
+                    value = editDraftBio,
+                    onValueChange = { if (it.length <= 400) editDraftBio = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 3,
+                    maxLines = 6,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                        cursorColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    placeholder = { Text("Расскажите о себе", color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.6f)) }
+                )
+                Text(
+                    "${editDraftBio.length}/400",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.7f),
+                    fontSize = 11.sp,
+                    modifier = Modifier.align(Alignment.End)
+                )
+                Spacer(Modifier.height(16.dp))
+                Text("Бейджи целей (до ${ProfileGoalBadges.MAX_SELECTED})", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp)
+                Spacer(Modifier.height(8.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    ProfileGoalBadges.all.forEach { opt ->
+                        val sel = opt.id in editSelectedBadges
+                        FilterChip(
+                            selected = sel,
+                            onClick = {
+                                editSelectedBadges = when {
+                                    sel -> editSelectedBadges - opt.id
+                                    editSelectedBadges.size >= ProfileGoalBadges.MAX_SELECTED -> editSelectedBadges
+                                    else -> editSelectedBadges + opt.id
+                                }
+                            },
+                            label = { Text(opt.label, fontSize = 13.sp) },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = MaterialTheme.colorScheme.primary.copy(0.35f),
+                                selectedLabelColor = MaterialTheme.colorScheme.onSurface,
+                                containerColor = MaterialTheme.colorScheme.outline.copy(0.4f),
+                                labelColor = MaterialTheme.colorScheme.onSurface
+                            )
+                        )
+                    }
+                }
+                Spacer(Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = { showProfileEditSheet = false },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                        enabled = !uiState.isSavingProfile
+                    ) { Text("Отмена") }
+                    Button(
+                        onClick = {
+                            profileViewModel.saveBioAndGoalBadges(
+                                userId,
+                                editDraftBio,
+                                editSelectedBadges.toList()
+                            ) { ok -> if (ok) showProfileEditSheet = false }
+                        },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                        enabled = !uiState.isSavingProfile
+                    ) {
+                        if (uiState.isSavingProfile) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(22.dp),
+                                color = Color.White,
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Text("Сохранить", fontWeight = FontWeight.SemiBold)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showChallengeSheet && !isOwnProfile) {
+        val rankFromProfile =
+            UserRank.entries.find { it.displayName == uiState.rankName } ?: UserRank.BEGINNER
+        val challengedUser = User(
+            id = userId,
+            nickname = uiState.username.ifBlank { "Игрок" },
+            email = uiState.email,
+            rank = rankFromProfile
+        )
+        ModalBottomSheet(
+            onDismissRequest = { showChallengeSheet = false },
+            sheetState = challengeSheetState
+        ) {
+            LaunchedEffect(Unit) { friendsViewModel.loadChallengePickerQuizzes() }
+            ChallengeFriendQuizSheetContent(
+                fixedFriend = challengedUser,
+                friends = emptyList(),
+                quizzes = friendsUiState.challengePickerQuizzes,
+                isLoading = friendsUiState.challengePickerLoading,
+                onDismiss = { showChallengeSheet = false },
+                onSendChallenge = { fid, qid, title ->
+                    friendsViewModel.sendChallenge(fid, qid, title)
+                }
+            )
         }
     }
 
     Scaffold(
         contentWindowInsets = WindowInsets.systemBars,
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = if (isOwnProfile) "Мой профиль" else "Профиль игрока",
-                        style = MaterialTheme.typography.displayLarge,
-                        color = MaterialTheme.colorScheme.inverseSurface
-                    )
-                },
-                actions = {
-                    if (isOwnProfile) {
-                        IconButton(onClick = {
-                            // TODO: навигация на экран редактирования профиля
-                        }) {
-                            Icon(
-                                imageVector = Icons.Default.Edit,
-                                contentDescription = "Редактировать профиль"
-                            )
-                        }
-                    }
-                },
-                modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)
-            )
-        },
+        containerColor = MaterialTheme.colorScheme.background,
         bottomBar = {
             BottomBar(
-                showBar = true,
-                currentRoute = currentRoute,
-                onHomeClick = onHomeClick,
-                onFriendsClick = onFriendsClick,
-                onProfileClick = onProfileClick
+                showBar              = true,
+                currentRoute         = currentRoute,
+                onHomeClick          = onHomeClick,
+                onLeaderboardClick   = onLeaderboardClick,
+                onChallengesClick    = onChallengesClick,
+                onQuizzesClick       = onQuizzesClick,
+                onProfileClick       = onProfileClick
             )
         },
         floatingActionButton = {
             if (!isOwnProfile) {
                 ExtendedFloatingActionButton(
-                    onClick = {
-                        Toast.makeText(context, "Вызов на дуэль отправлен!", Toast.LENGTH_SHORT).show()
-                    },
+                    onClick = { showChallengeSheet = true },
+                    shape = RoundedCornerShape(24.dp),
                     icon = { Icon(Icons.Default.Sports, contentDescription = null) },
-                    text = { Text("Вызвать на дуэль") }
+                    text = { Text("Вызвать на дуэль") },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = Color.White
                 )
             }
-        },
-        containerColor = MaterialTheme.colorScheme.secondary
+        }
     ) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            // Заголовок профиля
-            item {
-                ProfileHeader(
-                    userName = user?.displayName ?: "User $userId",
-                    userEmail = user?.email ?: "",
-                    userLevel = userLevel,
-                    nextLevelProgress = nextLevelProgress
+        if (uiState.isLoading && uiState.username.isBlank()) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
+                verticalArrangement = Arrangement.spacedBy(0.dp),
+                contentPadding = PaddingValues(bottom = 24.dp)
+            ) {
+                item {
+                    ProfileScreenTopBar(
+                        title = if (isOwnProfile) "Мой профиль" else "Профиль игрока",
+                        showEdit = isOwnProfile,
+                        onEditClick = { showProfileEditSheet = true },
+                        showSettings = isOwnProfile,
+                        onSettingsClick = { navController.navigate("settings") },
+                        onFriendsClick = if (isOwnProfile) {
+                            { navController.navigate("friends/$userId") }
+                        } else null
+                    )
+                }
+
+                item {
+                    Spacer(Modifier.height(12.dp))
+                    ProfileMainCard(
+                        userName = uiState.username.ifBlank { user?.displayName ?: "Игрок" },
+                        userEmail = uiState.email.ifBlank { user?.email ?: "" },
+                        userLevel = uiState.userLevel,
+                        levelProgress = uiState.levelProgress,
+                        rankName = uiState.rankName,
+                        avatarUrl = uiState.avatarUrl,
+                        isUploadingAvatar = uiState.isUploadingAvatar,
+                        onAvatarClick = if (isOwnProfile) {
+                            { avatarPicker.launch("image/*") }
+                        } else null
+                    )
+                }
+
+                item {
+                    Spacer(Modifier.height(14.dp))
+                    ProfileBioBadgesSection(
+                        bio = uiState.bio,
+                        badgeIds = uiState.interests
+                    )
+                }
+
+                item {
+                    Spacer(Modifier.height(16.dp))
+                    ProfileUserStatRow(stats = uiState.userStats)
+                }
+
+                item {
+                    Spacer(Modifier.height(20.dp))
+                    ProfileTopicStatsCard(topicStats = uiState.topicStats)
+                }
+
+                item {
+                    Spacer(Modifier.height(8.dp))
+                    ScrollableTabRow(
+                        selectedTabIndex = selectedTab,
+                        containerColor = MaterialTheme.colorScheme.background,
+                        contentColor = MaterialTheme.colorScheme.primary,
+                        edgePadding = 20.dp,
+                        indicator = { tabPositions ->
+                            if (selectedTab < tabPositions.size) {
+                                TabRowDefaults.Indicator(
+                                    modifier = Modifier
+                                        .tabIndicatorOffset(tabPositions[selectedTab])
+                                        .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp)),
+                                    height = 3.dp,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        },
+                        divider = { HorizontalDivider(color = MaterialTheme.colorScheme.outline, thickness = 1.dp) }
+                    ) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = selectedTab == index,
+                                onClick = { selectedTab = index },
+                                selectedContentColor = MaterialTheme.colorScheme.onSurface,
+                                unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                            ) {
+                                Text(
+                                    title,
+                                    fontWeight = if (selectedTab == index) FontWeight.SemiBold else FontWeight.Normal,
+                                    fontSize = 13.sp,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 14.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                when (selectedTab) {
+                    0 -> {
+                        if (uiState.createdQuizzes.isEmpty()) {
+                            item {
+                                EmptyTabHint("Вы ещё не создали викторин")
+                            }
+                        } else {
+                            itemsIndexed(
+                                items = uiState.createdQuizzes,
+                                key = { _, q -> q.id }
+                            ) { index, quiz ->
+                                CreatedQuizRow(
+                                    quiz = quiz,
+                                    colorIndex = index,
+                                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp),
+                                    onClick = { navController.navigate("quiz_detail/${quiz.id}") }
+                                )
+                            }
+                        }
+                    }
+                    1 -> {
+                        if (uiState.passedAttempts.isEmpty()) {
+                            item {
+                                EmptyTabHint("Пока нет завершённых прохождений")
+                            }
+                        } else {
+                            items(
+                                items = uiState.passedAttempts,
+                                key = { "${it.quizId}_${it.completedAtEpochMs}" }
+                            ) { attempt ->
+                                PassedQuizRow(
+                                    attempt = attempt,
+                                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp),
+                                    onClick = { navController.navigate("quiz_detail/${attempt.quizId}") }
+                                )
+                            }
+                        }
+                    }
+                    2 -> {
+                        items(
+                            items = uiState.achievements,
+                            key = { it.id }
+                        ) { achievement ->
+                            ProfileAchievementRow(
+                                achievement = achievement,
+                                modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp)
+                            )
+                        }
+                    }
+                }
+
+                if (isOwnProfile) {
+                    item { Spacer(Modifier.height(24.dp)) }
+                    item {
+                        OutlinedButton(
+                            onClick = {
+                                authViewModel.signOut()
+                                onNavigateToAuth()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                                .height(52.dp),
+                            shape = RoundedCornerShape(16.dp),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.Logout, null, tint = MaterialTheme.colorScheme.onSurface)
+                            Spacer(Modifier.width(8.dp))
+                            Text("Выйти", fontWeight = FontWeight.SemiBold)
+                        }
+                    }
+                    item {
+                        Spacer(Modifier.height(12.dp))
+                        OutlinedButton(
+                            onClick = { showDeleteDialog = true },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp)
+                                .height(52.dp),
+                            shape = RoundedCornerShape(16.dp),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.error)
+                        ) {
+                            Text("Удалить аккаунт", fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            containerColor = MaterialTheme.colorScheme.surface,
+            title = {
+                Text(
+                    "Удалить аккаунт?",
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Text(
+                    "Все данные, прогресс и достижения будут удалены навсегда.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 14.sp
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    authViewModel.deleteAccount()
+                    showDeleteDialog = false
+                }) {
+                    Text("Удалить", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Отмена", color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun ProfileScreenTopBar(
+    title: String,
+    showEdit: Boolean,
+    onEditClick: () -> Unit,
+    showSettings: Boolean = false,
+    onSettingsClick: () -> Unit = {},
+    onFriendsClick: (() -> Unit)? = null
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(
+                    listOf(MaterialTheme.colorScheme.surface, MaterialTheme.colorScheme.background)
+                )
+            )
+            .padding(top = 8.dp, bottom = 12.dp)
+    ) {
+        if (onFriendsClick != null) {
+            IconButton(
+                onClick = onFriendsClick,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Icon(
+                    Icons.Default.People,
+                    contentDescription = "Друзья",
+                    tint = MaterialTheme.colorScheme.onSurface.copy(0.85f)
                 )
             }
-
-            // Краткая статистика
-            item {
-                ProfileStatsRow(
-                    totalQuizzes = totalQuizzes,
-                    winPercentage = winPercentage,
-                    averageScore = averageScore
-                )
+        }
+        Text(
+            text = title,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp,
+            modifier = Modifier.align(Alignment.Center)
+        )
+        if (showSettings || showEdit) {
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (showSettings) {
+                    IconButton(onClick = onSettingsClick) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "Настройки",
+                            tint = MaterialTheme.colorScheme.onSurface.copy(0.85f)
+                        )
+                    }
+                }
+                if (showEdit) {
+                    IconButton(onClick = onEditClick) {
+                        Icon(Icons.Default.Edit, contentDescription = "Редактировать профиль", tint = MaterialTheme.colorScheme.onSurface.copy(0.85f))
+                    }
+                }
             }
-
-            // Статистика по темам
-            item { TopicStatsSection(topicStats = topicStats) }
-
-            // История игр
-            item { RecentGamesSection(recentGames = recentGames) }
-
-            // Достижения
-            item { AchievementsSection(achievements = achievements) }
         }
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Вспомогательные composable-ы и модели
-// ─────────────────────────────────────────────────────────────────────────────
-
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun ProfileHeader(
-    userName: String,
-    userEmail: String,
-    userLevel: Int,
-    nextLevelProgress: Float
+private fun ProfileBioBadgesSection(
+    bio: String,
+    badgeIds: List<String>
 ) {
-    Card(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            .padding(horizontal = 20.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.25f), RoundedCornerShape(20.dp))
+            .padding(16.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            // Аватар-заглушка
-            Surface(
-                modifier = Modifier.size(80.dp),
-                shape = androidx.compose.foundation.shape.CircleShape,
-                color = MaterialTheme.colorScheme.primary
+        Text("О себе", color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = bio.trim().ifBlank { "Пользователь пока ничего не написал." },
+            color = if (bio.isBlank()) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface.copy(0.92f),
+            fontSize = 14.sp,
+            lineHeight = 20.sp
+        )
+        if (badgeIds.isNotEmpty()) {
+            Spacer(Modifier.height(14.dp))
+            Text("Цели", color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+            Spacer(Modifier.height(8.dp))
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        text = userName.take(2).uppercase(),
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold
+                badgeIds.forEach { id ->
+                    val label = ProfileGoalBadges.labelFor(id) ?: id
+                    SuggestionChip(
+                        onClick = {},
+                        label = { Text(label, fontSize = 12.sp) },
+                        enabled = false,
+                        colors = SuggestionChipDefaults.suggestionChipColors(
+                            disabledContainerColor = MaterialTheme.colorScheme.primary.copy(0.2f),
+                            disabledLabelColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = SuggestionChipDefaults.suggestionChipBorder(
+                            enabled = false,
+                            borderColor = MaterialTheme.colorScheme.primary.copy(0.4f)
+                        )
                     )
                 }
             }
+        }
+    }
+}
 
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(text = userName, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-            Text(text = userEmail, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+@Composable
+private fun ProfileMainCard(
+    userName: String,
+    userEmail: String,
+    userLevel: Int,
+    levelProgress: Float,
+    rankName: String,
+    avatarUrl: String?,
+    isUploadingAvatar: Boolean,
+    onAvatarClick: (() -> Unit)?
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = levelProgress,
+        animationSpec = tween(600),
+        label = "lvl"
+    )
+    val ext = LocalBrainRacerExtendedColors.current
+    val g = ext.cardGradients
+    val avatarStops = listOf(g[0][0], g[1][0])
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.35f), RoundedCornerShape(20.dp))
+            .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape)
+                .then(
+                    if (onAvatarClick != null) Modifier.clickable(onClick = onAvatarClick)
+                    else Modifier
+                )
+                .background(Brush.linearGradient(avatarStops)),
+            contentAlignment = Alignment.Center
+        ) {
+            val url = avatarUrl?.takeIf { it.isNotBlank() }
+            if (url != null) {
+                AsyncImage(
+                    model = url,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Text(
+                    text = userName.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+            if (isUploadingAvatar) {
+                Box(
+                    Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.45f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(userName, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+        Text(userEmail, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            rankName,
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            "Уровень $userLevel",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 13.sp
+        )
+        Spacer(Modifier.height(6.dp))
+        LinearProgressIndicator(
+            progress = { animatedProgress },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(4.dp)),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.outline,
+            strokeCap = StrokeCap.Round
+        )
+    }
+}
 
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(text = "Уровень $userLevel", style = MaterialTheme.typography.labelMedium)
-            Spacer(modifier = Modifier.height(4.dp))
-            LinearProgressIndicator(
-                progress = nextLevelProgress,
-                modifier = Modifier.fillMaxWidth().height(8.dp),
-                strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
+@Composable
+private fun ProfileUserStatRow(stats: UserStats?) {
+    val accPct = if ((stats?.totalQuestionsAnswered ?: 0) > 0) {
+        val tq = stats!!.totalQuestionsAnswered
+        "${stats.correctAnswers.toLong() * 100L / tq}%"
+    } else "—"
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        listOf(
+            (stats?.totalQuizzesTaken ?: 0).toString() to "игр",
+            (stats?.totalPoints ?: 0).toString() to "рейтинг",
+            accPct to "точность"
+        ).forEach { (value, label) ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(72.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.surface)
+                    .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.25f), RoundedCornerShape(16.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(value, fontSize = 20.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+                    Text(label, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileTopicStatsCard(topicStats: List<TopicStatUi>) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.25f), RoundedCornerShape(20.dp))
+            .padding(16.dp)
+    ) {
+        Text(
+            "Статистика по темам",
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            fontSize = 16.sp
+        )
+        Spacer(Modifier.height(14.dp))
+        if (topicStats.isEmpty()) {
+            Text(
+                "Пройдите викторины, чтобы увидеть статистику по темам",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp
+            )
+        } else {
+            topicStats.forEach { stat ->
+                ProfileTopicRow(stat = stat)
+                Spacer(Modifier.height(12.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileTopicRow(stat: TopicStatUi) {
+    val topicBarColors = LocalBrainRacerExtendedColors.current.topicBarColors
+    val barColor = topicBarColors[stat.paletteIndex % topicBarColors.size]
+    Column {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(stat.categoryName, color = MaterialTheme.colorScheme.onSurface, fontSize = 14.sp)
+            Text(
+                "${stat.percent.toInt()}%",
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        LinearProgressIndicator(
+            progress = { (stat.percent / 100f).coerceIn(0f, 1f) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            color = barColor,
+            trackColor = MaterialTheme.colorScheme.outline,
+            strokeCap = StrokeCap.Round
+        )
+    }
+}
+
+@Composable
+private fun EmptyTabHint(message: String) {
+    Text(
+        message,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontSize = 14.sp,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 32.dp)
+    )
+}
+
+@Composable
+private fun CreatedQuizRow(
+    quiz: QuizItem,
+    colorIndex: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val cardGradients = LocalBrainRacerExtendedColors.current.cardGradients
+    val gradient = cardGradients[colorIndex % cardGradients.size]
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(86.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            Modifier.fillMaxSize().padding(13.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(54.dp)
+                    .clip(RoundedCornerShape(13.dp))
+                    .background(Brush.linearGradient(gradient, Offset.Zero, Offset(400f, 400f))),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Quiz, null, tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(26.dp))
+            }
+            Spacer(Modifier.width(13.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    quiz.title,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(quiz.category, fontSize = 12.sp, color = MaterialTheme.colorScheme.primary)
+                    Text("·", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("${quiz.questionCount} вопр.", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Icon(Icons.Default.ChevronRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp))
+        }
+    }
+}
+
+@Composable
+private fun PassedQuizRow(
+    attempt: PassedQuizUi,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+            .padding(14.dp)
+    ) {
+        Text(attempt.title, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.SemiBold, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Spacer(Modifier.height(4.dp))
+        Text(attempt.category, color = MaterialTheme.colorScheme.primary, fontSize = 12.sp)
+        Spacer(Modifier.height(8.dp))
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                "Точность: ${attempt.accuracyPercent}%",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp
+            )
+            Text(
+                "+${attempt.pointsEarned} XP",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+        Text(
+            ProfileUtils.formatPassedDate(attempt.completedAtEpochMs),
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(0.8f),
+            fontSize = 11.sp,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun ProfileAchievementRow(
+    achievement: AchievementUi,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(14.dp))
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = if (achievement.unlocked) Icons.Default.CheckCircle else Icons.Default.Lock,
+            contentDescription = null,
+            modifier = Modifier.size(36.dp),
+            tint = if (achievement.unlocked) LocalBrainRacerExtendedColors.current.detailGreen
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(0.4f)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                achievement.title,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 15.sp
+            )
+            Text(
+                achievement.description,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp
             )
         }
     }
 }
 
-@Composable
-fun ProfileStatsRow(totalQuizzes: Int, winPercentage: Int, averageScore: Double) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        StatCard(modifier = Modifier.weight(1f), label = "Игр", value = "$totalQuizzes")
-        StatCard(modifier = Modifier.weight(1f), label = "Побед", value = "$winPercentage%")
-        StatCard(modifier = Modifier.weight(1f), label = "Рейтинг", value = "$averageScore")
-    }
-}
-
-@Composable
-private fun StatCard(modifier: Modifier = Modifier, label: String, value: String) {
-    Card(
-        modifier = modifier,
-        shape = RoundedCornerShape(12.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(text = value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-            Text(text = label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-    }
-}
-
-@Composable
-fun TopicStatsSection(topicStats: List<TopicStat>) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = "Статистика по темам", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Spacer(modifier = Modifier.height(12.dp))
-            topicStats.forEach { stat ->
-                TopicStatItem(stat = stat)
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-        }
-    }
-}
-
-@Composable
-fun TopicStatItem(stat: TopicStat) {
-    Column {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(text = stat.name, style = MaterialTheme.typography.bodyMedium)
-            Text(text = "${stat.score.toInt()}%", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-        }
-        Spacer(modifier = Modifier.height(4.dp))
-        LinearProgressIndicator(
-            progress = stat.score / 100f,
-            modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
-            color = stat.color,
-            strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
-        )
-    }
-}
-
-@Composable
-fun RecentGamesSection(recentGames: List<RecentGame>) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = "Последние игры", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Spacer(modifier = Modifier.height(12.dp))
-            recentGames.forEach { game ->
-                RecentGameItem(game = game)
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-        }
-    }
-}
-
-@Composable
-fun RecentGameItem(game: RecentGame) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = if (game.result == "Победа") Icons.Default.EmojiEvents else Icons.Default.Close,
-            contentDescription = null,
-            modifier = Modifier.size(24.dp),
-            tint = if (game.result == "Победа") MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(text = game.topic, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-            Text(text = game.timeAgo, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-        Text(
-            text = game.result,
-            style = MaterialTheme.typography.labelMedium,
-            color = if (game.result == "Победа") MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-            fontWeight = FontWeight.Bold
-        )
-    }
-}
-
-@Composable
-fun AchievementsSection(achievements: List<Achievement>) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = "Достижения", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Spacer(modifier = Modifier.height(12.dp))
-            achievements.forEach { achievement ->
-                AchievementItem(achievement = achievement)
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-        }
-    }
-}
-
-@Composable
-fun AchievementItem(achievement: Achievement) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = if (achievement.achieved) Icons.Default.CheckCircle else Icons.Default.Lock,
-            contentDescription = null,
-            modifier = Modifier.size(32.dp),
-            tint = if (achievement.achieved) MaterialTheme.colorScheme.primary
-            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(text = achievement.title, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-            Text(text = achievement.description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-        }
-    }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-//  Модели данных
-// ─────────────────────────────────────────────────────────────────────────────
-
-data class TopicStat(val name: String, val score: Float, val color: Color)
-data class RecentGame(val topic: String, val result: String, val score: Float, val timeAgo: String)
-data class Achievement(val title: String, val description: String, val achieved: Boolean)
-
-// ─────────────────────────────────────────────────────────────────────────────
-//  Preview
-// ─────────────────────────────────────────────────────────────────────────────
-
 @Preview(showBackground = true)
 @Composable
 fun ProfileScreenPreview() {
-    MaterialTheme {
-        ProfileScreen(onNavigateToAuth = {}, userId = "user123", isOwnProfile = true)
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun OtherProfileScreenPreview() {
-    MaterialTheme {
-        ProfileScreen(onNavigateToAuth = {}, userId = "user456", isOwnProfile = false)
+    BrainRacerTheme {
+        ProfileScreen(
+            navController = rememberNavController(),
+            onNavigateToAuth = {},
+            userId = "user123",
+            isOwnProfile = true
+        )
     }
 }

--- a/app/src/main/java/com/example/brainracer/ui/screens/ProfileScreen_v2.kt
+++ b/app/src/main/java/com/example/brainracer/ui/screens/ProfileScreen_v2.kt
@@ -79,14 +79,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.brainracer.ui.components.BottomBar
-import com.example.brainracer.ui.theme.onBackgroundLight
-import com.example.brainracer.ui.theme.onSurfaceVariantLight
-import com.example.brainracer.ui.theme.primaryContainerLight
-import com.example.brainracer.ui.theme.primaryLight
-import com.example.brainracer.ui.theme.surfaceContainerHighLight
-import com.example.brainracer.ui.theme.surfaceContainerLight
-import com.example.brainracer.ui.theme.surfaceContainerLowLight
-import com.example.brainracer.ui.theme.surfaceLight
+import com.example.brainracer.ui.theme.BrainRacerColorTokens
+import com.example.brainracer.ui.theme.BrainRacerTheme
+import com.example.brainracer.ui.theme.LocalBrainRacerExtendedColors
 import com.example.brainracer.ui.viewmodels.AuthViewModel
 
 
@@ -146,12 +141,13 @@ fun ProfileScreenNew(
     }
 
     val topicStats = remember {
+        val c = BrainRacerColorTokens.TopicBarColors
         listOf(
-            ProfileTopicStat("Математика", 85f, Color(0xFF4CAF50), Icons.Default.TrendingUp),
-            ProfileTopicStat("История", 65f, Color(0xFF2196F3), Icons.Default.Person),
-            ProfileTopicStat("Программирование", 92f, Color(0xFF9C27B0), Icons.Default.Code),
-            ProfileTopicStat("География", 78f, Color(0xFFFF9800), Icons.Default.Public),
-            ProfileTopicStat("Биология", 54f, Color(0xFFE91E63), Icons.Default.Science)
+            ProfileTopicStat("Математика", 85f, c[2], Icons.Default.TrendingUp),
+            ProfileTopicStat("История", 65f, c[3], Icons.Default.Person),
+            ProfileTopicStat("Программирование", 92f, c[4], Icons.Default.Code),
+            ProfileTopicStat("География", 78f, c[0], Icons.Default.Public),
+            ProfileTopicStat("Биология", 54f, c[1], Icons.Default.Science)
         )
     }
 
@@ -177,7 +173,7 @@ fun ProfileScreenNew(
             .fillMaxSize()
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         contentWindowInsets = WindowInsets.systemBars,
-        containerColor = surfaceContainerLowLight,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         topBar = {
             TopAppBar(
                 title = {
@@ -185,7 +181,7 @@ fun ProfileScreenNew(
                         text = if (isOwnProfile) "Мой профиль" else "Профиль игрока",
                         fontWeight = FontWeight.SemiBold,
                         fontSize = 18.sp,
-                        color = onBackgroundLight
+                        color = MaterialTheme.colorScheme.onBackground
                     )
                 },
                 actions = {
@@ -193,26 +189,29 @@ fun ProfileScreenNew(
                         IconButton(onClick = {
                             Toast.makeText(context, "Поделиться", Toast.LENGTH_SHORT).show()
                         }) {
-                            Icon(Icons.Default.Share, contentDescription = null, tint = onSurfaceVariantLight)
+                            Icon(Icons.Default.Share, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                         IconButton(onClick = {}) {
-                            Icon(Icons.Default.Edit, contentDescription = null, tint = onSurfaceVariantLight)
+                            Icon(Icons.Default.Edit, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = surfaceContainerLowLight,
-                    scrolledContainerColor = surfaceContainerHighLight
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                 ),
                 scrollBehavior = scrollBehavior
             )
         },
         bottomBar = {
             BottomBar(
-                showBar = true,
-                currentRoute = currentRoute,
-                onHomeClick = onHomeClick,
-                onProfileClick = onProfileClick
+                showBar              = true,
+                currentRoute         = currentRoute,
+                onHomeClick          = onHomeClick,
+                onLeaderboardClick   = {},
+                onChallengesClick    = {},
+                onQuizzesClick       = {},
+                onProfileClick       = onProfileClick
             )
         },
         floatingActionButton = {
@@ -221,7 +220,7 @@ fun ProfileScreenNew(
                     onClick = { Toast.makeText(context, "Вызов отправлен!", Toast.LENGTH_SHORT).show() },
                     icon = { Icon(Icons.Default.Sports, contentDescription = null) },
                     text = { Text("Вызвать") },
-                    containerColor = primaryLight,
+                    containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = Color.White
                 )
             }
@@ -285,7 +284,7 @@ fun ProfileScreenNew(
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
-            containerColor = surfaceLight,
+            containerColor = MaterialTheme.colorScheme.surface,
             shape = RoundedCornerShape(20.dp),
             title = {
                 Text("Удалить аккаунт?", color = MaterialTheme.colorScheme.error, fontWeight = FontWeight.Bold)
@@ -293,7 +292,7 @@ fun ProfileScreenNew(
             text = {
                 Text(
                     "Все данные, прогресс и достижения будут удалены навсегда.",
-                    color = onSurfaceVariantLight
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             },
             confirmButton = {
@@ -306,7 +305,7 @@ fun ProfileScreenNew(
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("Отмена", color = onBackgroundLight)
+                    Text("Отмена", color = MaterialTheme.colorScheme.onBackground)
                 }
             }
         )
@@ -333,7 +332,7 @@ fun ProfileHeaderSection(
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(containerColor = surfaceLight),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(2.dp)
     ) {
         Column(
@@ -345,40 +344,41 @@ fun ProfileHeaderSection(
                 modifier = Modifier
                     .size(90.dp)
                     .clip(CircleShape)
-                    .background(primaryContainerLight.copy(alpha = 0.25f))
-                    .border(3.dp, primaryLight.copy(alpha = 0.35f), CircleShape),
+                    .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.25f))
+                    .border(3.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.35f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(Icons.Default.Person, null, Modifier.size(44.dp), tint = primaryLight)
+                Icon(Icons.Default.Person, null, Modifier.size(44.dp), tint = MaterialTheme.colorScheme.primary)
             }
 
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(userName, fontWeight = FontWeight.Bold, fontSize = 20.sp, color = onBackgroundLight)
+                Text(userName, fontWeight = FontWeight.Bold, fontSize = 20.sp, color = MaterialTheme.colorScheme.onBackground)
                 if (userEmail.isNotEmpty()) {
-                    Text(userEmail, fontSize = 13.sp, color = onSurfaceVariantLight)
+                    Text(userEmail, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
 
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                Surface(shape = RoundedCornerShape(12.dp), color = primaryLight.copy(alpha = 0.10f)) {
+                Surface(shape = RoundedCornerShape(12.dp), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)) {
                     Row(
                         modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
-                        Icon(Icons.Default.EmojiEvents, null, Modifier.size(15.dp), tint = primaryLight)
-                        Text("Уровень $userLevel", fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = primaryLight)
+                        Icon(Icons.Default.EmojiEvents, null, Modifier.size(15.dp), tint = MaterialTheme.colorScheme.primary)
+                        Text("Уровень $userLevel", fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = MaterialTheme.colorScheme.primary)
                     }
                 }
                 if (currentStreak > 0) {
-                    Surface(shape = RoundedCornerShape(12.dp), color = Color(0xFFFFA726).copy(alpha = 0.10f)) {
+                    val streak = LocalBrainRacerExtendedColors.current.statusOrange
+                    Surface(shape = RoundedCornerShape(12.dp), color = streak.copy(alpha = 0.10f)) {
                         Row(
                             modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(6.dp)
                         ) {
-                            Icon(Icons.Default.LocalFireDepartment, null, Modifier.size(15.dp), tint = Color(0xFFFFA726))
-                            Text("$currentStreak дней", fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Color(0xFFE65100))
+                            Icon(Icons.Default.LocalFireDepartment, null, Modifier.size(15.dp), tint = streak)
+                            Text("$currentStreak дней", fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = streak)
                         }
                     }
                 }
@@ -386,14 +386,14 @@ fun ProfileHeaderSection(
 
             Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Text("До уровня ${userLevel + 1}", fontSize = 12.sp, color = onSurfaceVariantLight)
-                    Text("${(progress * 100).toInt()}%", fontSize = 12.sp, color = primaryLight, fontWeight = FontWeight.SemiBold)
+                    Text("До уровня ${userLevel + 1}", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("${(progress * 100).toInt()}%", fontSize = 12.sp, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.SemiBold)
                 }
                 LinearProgressIndicator(
                     progress = { animatedProgress },
                     modifier = Modifier.fillMaxWidth().height(7.dp).clip(RoundedCornerShape(4.dp)),
-                    color = primaryLight,
-                    trackColor = surfaceContainerLight,
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.surfaceContainer,
                     strokeCap = StrokeCap.Round
                 )
             }
@@ -408,9 +408,9 @@ fun StatsRow(totalQuizzes: Int, winPercentage: Int, averageScore: Double) {
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        SimpleStatCard("Сыграно", "$totalQuizzes", Icons.Default.Gamepad, Color(0xFF5C6BC0), Modifier.weight(1f))
-        SimpleStatCard("Побед", "$winPercentage%", Icons.Default.EmojiEvents, primaryLight, Modifier.weight(1f))
-        SimpleStatCard("Рейтинг", String.format("%.1f", averageScore), Icons.Default.Star, Color(0xFFFF8F00), Modifier.weight(1f))
+        SimpleStatCard("Сыграно", "$totalQuizzes", Icons.Default.Gamepad, BrainRacerColorTokens.TopicBarColors[3], Modifier.weight(1f))
+        SimpleStatCard("Побед", "$winPercentage%", Icons.Default.EmojiEvents, MaterialTheme.colorScheme.primary, Modifier.weight(1f))
+        SimpleStatCard("Рейтинг", String.format("%.1f", averageScore), Icons.Default.Star, BrainRacerColorTokens.TopicBarColors[0], Modifier.weight(1f))
     }
 }
 
@@ -419,7 +419,7 @@ fun SimpleStatCard(title: String, value: String, icon: ImageVector, color: Color
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = surfaceLight),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(1.dp)
     ) {
         Column(
@@ -433,8 +433,8 @@ fun SimpleStatCard(title: String, value: String, icon: ImageVector, color: Color
             ) {
                 Icon(icon, null, Modifier.size(17.dp), tint = color)
             }
-            Text(value, fontWeight = FontWeight.Bold, fontSize = 17.sp, color = onBackgroundLight)
-            Text(title, fontSize = 11.sp, color = onSurfaceVariantLight)
+            Text(value, fontWeight = FontWeight.Bold, fontSize = 17.sp, color = MaterialTheme.colorScheme.onBackground)
+            Text(title, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
@@ -446,7 +446,7 @@ fun SectionHeader(title: String) {
         text = title,
         fontWeight = FontWeight.SemiBold,
         fontSize = 14.sp,
-        color = onSurfaceVariantLight,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 6.dp, bottom = 4.dp)
     )
 }
@@ -457,7 +457,7 @@ fun TopicsCard(topics: List<ProfileTopicStat>) {
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = surfaceLight),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(1.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -475,7 +475,7 @@ fun TopicsCard(topics: List<ProfileTopicStat>) {
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             Icon(topic.icon, null, Modifier.size(15.dp), tint = topic.color)
-                            Text(topic.name, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = onBackgroundLight)
+                            Text(topic.name, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onBackground)
                         }
                         Text("${topic.score.toInt()}%", fontSize = 13.sp, fontWeight = FontWeight.Bold, color = topic.color)
                     }
@@ -483,12 +483,12 @@ fun TopicsCard(topics: List<ProfileTopicStat>) {
                         progress = { animated },
                         modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
                         color = topic.color,
-                        trackColor = surfaceContainerLight,
+                        trackColor = MaterialTheme.colorScheme.surfaceContainer,
                         strokeCap = StrokeCap.Round
                     )
                 }
                 if (index < topics.lastIndex) {
-                    HorizontalDivider(color = surfaceContainerLight, thickness = 0.5.dp)
+                    HorizontalDivider(color = MaterialTheme.colorScheme.surfaceContainer, thickness = 0.5.dp)
                 }
             }
         }
@@ -499,8 +499,9 @@ fun TopicsCard(topics: List<ProfileTopicStat>) {
 @Composable
 fun GameRow(game: ProfileRecentGame) {
     val isWin = game.result == "Победа"
-    val accentColor = if (isWin) Color(0xFF388E3C) else Color(0xFFC62828)
-    val bgColor = if (isWin) Color(0xFF4CAF50).copy(alpha = 0.07f) else Color(0xFFE57373).copy(alpha = 0.07f)
+    val ext = LocalBrainRacerExtendedColors.current
+    val accentColor = if (isWin) ext.detailGreen else MaterialTheme.colorScheme.error
+    val bgColor = if (isWin) ext.detailGreen.copy(alpha = 0.07f) else MaterialTheme.colorScheme.error.copy(alpha = 0.07f)
 
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
@@ -514,13 +515,13 @@ fun GameRow(game: ProfileRecentGame) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(game.topic, fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = onBackgroundLight)
-                Text(game.timeAgo, fontSize = 12.sp, color = onSurfaceVariantLight)
+                Text(game.topic, fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = MaterialTheme.colorScheme.onBackground)
+                Text(game.timeAgo, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(3.dp)) {
-                    Icon(Icons.Default.Star, null, Modifier.size(13.dp), tint = Color(0xFFFFA000))
-                    Text(String.format("%.1f", game.score), fontSize = 13.sp, fontWeight = FontWeight.Bold, color = onBackgroundLight)
+                    Icon(Icons.Default.Star, null, Modifier.size(13.dp), tint = LocalBrainRacerExtendedColors.current.difficultyExpert)
+                    Text(String.format("%.1f", game.score), fontSize = 13.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onBackground)
                 }
                 Surface(shape = RoundedCornerShape(8.dp), color = accentColor.copy(alpha = 0.13f)) {
                     Text(
@@ -542,7 +543,7 @@ fun AchievementsCard(achievements: List<ProfileAchievement>) {
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = surfaceLight),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(1.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -555,11 +556,11 @@ fun AchievementsCard(achievements: List<ProfileAchievement>) {
                         modifier = Modifier
                             .size(36.dp)
                             .clip(CircleShape)
-                            .background(if (it.achieved) primaryLight.copy(alpha = 0.11f) else surfaceContainerLight),
+                            .background(if (it.achieved) MaterialTheme.colorScheme.primary.copy(alpha = 0.11f) else MaterialTheme.colorScheme.surfaceContainer),
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(it.icon, null, Modifier.size(18.dp),
-                            tint = if (it.achieved) primaryLight else onSurfaceVariantLight.copy(alpha = 0.3f))
+                            tint = if (it.achieved) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f))
                     }
                     Spacer(Modifier.width(12.dp))
                     Column(Modifier.weight(1f)) {
@@ -567,19 +568,19 @@ fun AchievementsCard(achievements: List<ProfileAchievement>) {
                             it.title,
                             fontWeight = FontWeight.SemiBold,
                             fontSize = 13.sp,
-                            color = if (it.achieved) onBackgroundLight else onSurfaceVariantLight.copy(alpha = 0.45f)
+                            color = if (it.achieved) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
                         )
-                        Text(it.description, fontSize = 12.sp, color = onSurfaceVariantLight)
+                        Text(it.description, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                     Icon(
                         if (it.achieved) Icons.Default.CheckCircle else Icons.Default.Lock,
                         null,
                         Modifier.size(18.dp),
-                        tint = if (it.achieved) Color(0xFF4CAF50) else onSurfaceVariantLight.copy(alpha = 0.22f)
+                        tint = if (it.achieved) LocalBrainRacerExtendedColors.current.detailGreen else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.22f)
                     )
                 }
                 if (index < achievements.lastIndex) {
-                    HorizontalDivider(color = surfaceContainerLight, thickness = 0.5.dp)
+                    HorizontalDivider(color = MaterialTheme.colorScheme.surfaceContainer, thickness = 0.5.dp)
                 }
             }
         }
@@ -597,7 +598,7 @@ fun ActionsSection(onSignOut: () -> Unit, onDeleteClick: () -> Unit) {
             onClick = onSignOut,
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = onSurfaceVariantLight)
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurfaceVariant)
         ) {
             Icon(Icons.AutoMirrored.Filled.Logout, null, Modifier.size(17.dp))
             Spacer(Modifier.width(8.dp))
@@ -620,7 +621,7 @@ fun ActionsSection(onSignOut: () -> Unit, onDeleteClick: () -> Unit) {
 @Preview(showBackground = true, device = "spec:parent=pixel_5,orientation=portrait")
 @Composable
 fun ProfileScreenPreviewNew() {
-    MaterialTheme {
+    BrainRacerTheme {
         ProfileScreenNew(onNavigateToAuth = {}, userId = "user123", isOwnProfile = true)
     }
 }
@@ -628,7 +629,7 @@ fun ProfileScreenPreviewNew() {
 @Preview(showBackground = true, device = "spec:parent=pixel_5,orientation=portrait")
 @Composable
 fun OtherProfileScreenPreviewNew() {
-    MaterialTheme {
+    BrainRacerTheme {
         ProfileScreenNew(onNavigateToAuth = {}, userId = "user456", isOwnProfile = false)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to large UI refactors (especially `ProfileScreen`) plus navigation/API surface changes in bottom bar callbacks and new intent-driven share/avatar-pick flows that can introduce regressions in routing and state handling.
> 
> **Overview**
> Updates multiple screens to use **Material3 theme colors** (and `LocalBrainRacerExtendedColors`) instead of hardcoded palettes, unifying styling across challenge start/list/review and profile UIs.
> 
> Revamps navigation wiring by switching screens over to the expanded `BottomBar` callback set, and enhances `FriendsScreen` with RU text, profile deep-links from search/friends/requests, and an **Invite friends** share intent.
> 
> Replaces the old demo `ProfileScreen` with a data-driven implementation backed by `ProfileViewModel`/`FriendsViewModel`: adds avatar upload, editable bio + goal badges, tabs for created/passed/achievements, challenge-from-profile via bottom sheet, and updated sign-out/delete account actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d220ce451896d0bab1837a576d0b4366dbf15570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->